### PR TITLE
adds buttons for map interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.1.0",
         "react-code-blocks": "^0.0.9-0",
-        "react-dom": "^17.0.2",
+        "react-dom": "^18.1.0",
         "react-leaflet": "^3.2.5",
         "react-leaflet-draw": "^0.19.8",
         "react-redux": "^7.2.6",
@@ -12681,16 +12681,23 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.22.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.1.0"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+      "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-is": {
@@ -13317,6 +13324,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -24843,13 +24851,22 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
+      "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.22.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.22.0.tgz",
+          "integrity": "sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==",
+          "requires": {
+            "loose-envify": "^1.1.0"
+          }
+        }
       }
     },
     "react-is": {
@@ -25322,6 +25339,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.1.0",
     "react-code-blocks": "^0.0.9-0",
-    "react-dom": "^17.0.2",
+    "react-dom": "^18.1.0",
     "react-leaflet": "^3.2.5",
     "react-leaflet-draw": "^0.19.8",
     "react-redux": "^7.2.6",

--- a/src/components/All/UpperRightIconButton.js
+++ b/src/components/All/UpperRightIconButton.js
@@ -1,0 +1,55 @@
+/*
+Purpose
+    Upper Right Buttons on cards and menus typically:
+      - Help or Information
+      - Minimize
+
+      TODO: needs click handler passed in
+Child Components
+  - Not sure yet
+
+Libs
+  - Not sure yet
+
+API
+  - Not sure yet
+
+State needed
+  - Not sure yet
+
+Props
+  - label for ally
+  - icon as child
+*/
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import IconButton from '@mui/material/IconButton';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    height: theme.spacing(4.5),
+    padding: theme.spacing(0.375)
+  }
+}));
+
+export default function UpperRightIconButton(props) {
+  const { children, ariaLabel } = props;
+  const classes = useStyles();
+
+  return (
+    <IconButton
+      variant="contained"
+      color="CRESTPrimary"
+      className={classes.actionButton}
+      aria-label={ariaLabel}>
+      {children}
+    </IconButton>
+  );
+}
+
+UpperRightIconButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  ariaLabel: PropTypes.string.isRequired
+};

--- a/src/components/Map/ActionButton.js
+++ b/src/components/Map/ActionButton.js
@@ -24,3 +24,64 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { makeStyles } from '@mui/styles';
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    borderRadius: 0,
+    maxHeight: theme.spacing(8),
+    textTransform: 'none',
+    flexWrap: 'wrap',
+    '&:hover': {
+      backgroundColor: '#6f6f6f'
+    }
+  },
+  buttonHolder: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  button: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function ActionButton(props) {
+  const classes = useStyles();
+  const {
+    children,
+    buttonLabel,
+    buttonName
+  } = props;
+
+  return (
+    <Box className={classes.buttonHolder}>
+      <Button
+        variant="text"
+        color="CRESTPrimary"
+        fullWidth={true}
+        aria-label={buttonName}
+        className={classes.actionButton}>
+        <Box component="div" className={classes.button} pt={0.5}>{children}</Box>
+        <Box component="div" sclassName={classes.button} pb={0.5}>{buttonLabel}</Box>
+      </Button>
+    </Box>
+  );
+}
+
+ActionButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  buttonName: PropTypes.string.isRequired
+};

--- a/src/components/Map/ActionButtons.js
+++ b/src/components/Map/ActionButtons.js
@@ -8,7 +8,7 @@ Purpose
     - map layers opens the map layer list
 
 Child Components
-  - Map-ActionButton.js
+  - ActionButton.js
 
 Libs
   - Not sure yet
@@ -24,3 +24,62 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+
+import Grid from '@mui/material/Grid';
+
+import {
+  CameraAlt,
+  // LayersOutlined,
+  Layers,
+  // LibraryAddOutlined,
+  LibraryAdd
+} from '@mui/icons-material';
+
+import { makeStyles } from '@mui/styles';
+
+import ActionButton from './ActionButton';
+
+const useStyles = makeStyles((theme) => ({
+  contentGrid: {
+    height: theme.spacing(8),
+    padding: theme.spacing(0),
+    backgroundColor: theme.palette.CRESTGridBackground.dark,
+    borderColor: theme.palette.CRESTBorderColor.main,
+    borderStyle: 'solid',
+    borderWidth: '1px'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function ActionButtons() {
+  const classes = useStyles();
+
+  return (
+    <Grid container spacing={0} justifyContent="center" alignItems="center" className={classes.contentGrid}>
+
+      <Grid item xs={4}>
+        <ActionButton
+          buttonLabel={'Add Area'}
+          buttonName={'Add Area'}>
+          <LibraryAdd />
+        </ActionButton>
+      </Grid>
+      <Grid item xs={4}>
+        <ActionButton
+          buttonLabel={'Export'}
+          buttonName={'Export'}>
+          <CameraAlt />
+        </ActionButton>
+      </Grid>
+      <Grid item xs={4}>
+        <ActionButton
+          buttonLabel={'Map Layers'}
+          buttonName={'Map Layers'}>
+          <Layers />
+        </ActionButton>
+      </Grid>
+
+    </Grid>
+  );
+}

--- a/src/components/Map/Buffer.js
+++ b/src/components/Map/Buffer.js
@@ -18,3 +18,39 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { makeStyles } from '@mui/styles';
+import {
+  // CheckBoxOutlineBlank,
+  CheckBox
+} from '@mui/icons-material';
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    height: theme.spacing(4.5),
+    textTransform: 'none',
+    justifyContent: 'start'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function Buffer(props) {
+  const classes = useStyles();
+
+  return (
+    <Box p={0.75} >
+      <Button
+        variant="text"
+        color="CRESTPrimary"
+        fullWidth={true}
+        aria-label={'Include a Buffer to Understand Nearby Impacts'}
+        className={classes.actionButton}
+        startIcon={<CheckBox />}>
+        Include a Buffer to Understand Nearby Impacts
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/Map/DrawArea.js
+++ b/src/components/Map/DrawArea.js
@@ -32,3 +32,39 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { makeStyles } from '@mui/styles';
+import {
+  PolylineOutlined
+  // Polyline
+} from '@mui/icons-material';
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    height: theme.spacing(4.5),
+    textTransform: 'none',
+    justifyContent: 'start'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function DrawArea(props) {
+  const classes = useStyles();
+
+  return (
+    <Box p={0.75} >
+      <Button
+        variant="contained"
+        color="CRESTPrimary"
+        fullWidth={true}
+        aria-label={'Sketch an Area'}
+        className={classes.actionButton}
+        startIcon={<PolylineOutlined />}>
+        Sketch an Area
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/Map/MapActionCard.js
+++ b/src/components/Map/MapActionCard.js
@@ -6,7 +6,6 @@ Purpose
       - search county or water shed
       - buffer
 
-      // TODO: need to add these to sperate component.js files for each action
 Child Components
   - upload.js
 
@@ -22,3 +21,81 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import { makeStyles } from '@mui/styles';
+import Typography from '@mui/material/Typography';
+
+import {
+  ArrowDropDownCircle,
+  Help,
+  LibraryAdd
+} from '@mui/icons-material';
+
+import Buffer from './Buffer';
+import DrawArea from './DrawArea';
+import SearchCustom from './SearchCustom';
+import Upload from './Upload';
+import UpperRightIconButton from '../All/UpperRightIconButton';
+
+const useStyles = makeStyles((theme) => ({
+  contentGrid: {
+    height: '250px',
+    padding: theme.spacing(0),
+    backgroundColor: theme.palette.CRESTGridBackground.dark,
+    borderColor: theme.palette.CRESTBorderColor.main,
+    borderStyle: 'solid',
+    borderWidth: '1px'
+  },
+  titleBox: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center'
+  },
+  titleBoxTypography: {
+    cursor: 'default',
+    width: '100%',
+    alignItems: 'center'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function MapActionCard() {
+  const classes = useStyles();
+
+  return (
+    <Grid container spacing={0} justifyContent="center" alignItems="center" className={classes.contentGrid}>
+
+      <Grid item xs={12}>
+        <Box px={1} py={0.75} className={classes.titleBox}>
+          <LibraryAdd />
+          <Typography px={1} className={classes.titleBoxTypography}>
+            Add an area to analyze
+          </Typography>
+          <UpperRightIconButton ariaLabel="Help">
+            <Help />
+          </UpperRightIconButton>
+          <UpperRightIconButton ariaLabel="Minimize">
+            <ArrowDropDownCircle />
+          </UpperRightIconButton>
+        </Box>
+      </Grid>
+
+      <Grid item xs={12}>
+        <DrawArea />
+      </Grid>
+      <Grid item xs={12}>
+        <Upload />
+      </Grid>
+      <Grid item xs={12}>
+        <SearchCustom />
+      </Grid>
+      <Grid item xs={12}>
+        <Buffer />
+      </Grid>
+
+    </Grid>
+  );
+}

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -50,7 +50,8 @@ import { mapConfig } from '../../configuration/config';
 import { BasicSelect } from './basicSelect';
 import { changeRegion } from '../../reducers/regionSelectSlice';
 import { changeZoom, changeCenter } from '../../reducers/mapPropertiesSlice';
-import Boxforlayout from './BoxForLayouts';
+import ActionButtons from './ActionButtons';
+// import Boxforlayout from './BoxForLayouts';
 
 const useStyles = makeStyles((theme) => ({
   leafletContainer: {
@@ -131,11 +132,7 @@ export default function MapCard() {
                 values={Object.keys(regions)}
                 onChange={handleRegionSelectChange}/> : null}
       {displayMap}
-      <Boxforlayout
-        boxHeight={'64px'} >
-        Map Action buttons - add area, export, map layers, this is a place holder
-        for the actual component
-      </Boxforlayout>
+      <ActionButtons />
     </div>
   );
 }

--- a/src/components/Map/MapHolder.js
+++ b/src/components/Map/MapHolder.js
@@ -27,6 +27,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 
 import MapCard from './MapCard';
+import MapActionCard from './MapActionCard';
 import Boxforlayout from './BoxForLayouts';
 
 const useStyles = makeStyles((theme) => ({
@@ -81,16 +82,12 @@ export default function MapHolder(props) {
 
        {/* Data (graph/chart/table, action buttons) */}
       <Grid item
-        xs={12} sm={12} md={4} lg={4}
+        xs={12} sm={12} md={4} lg={3}
         order={{ xs: 3, sm: 3, md: 1 }}
         className={classes.threeColumnHolder}>
+        <MapActionCard />
         <Boxforlayout
-          boxHeight={'200px'} >
-          Map Actions - sketch, upload, search, this is a place holder for the
-          actual component
-        </Boxforlayout>
-        <Boxforlayout
-          boxHeight={'calc(100% - 208px)'}
+          boxHeight={'calc(100% - 258px)'}
           boxMarginTop={'8px'}>
           Graphs/Data/Messages, this is a place holder for the actual component
         </Boxforlayout>
@@ -98,7 +95,7 @@ export default function MapHolder(props) {
 
       {/* Map */}
      <Grid item
-       xs={12} sm={12} md={5} lg={6}
+       xs={12} sm={12} md={5} lg={7}
        order={{ xs: 1, sm: 1, md: 2 }}
        className={classes.threeColumnHolder}>
        <Box className={classes.contentmapBox} style={{ height: '100%' }}>

--- a/src/components/Map/SearchCustom.js
+++ b/src/components/Map/SearchCustom.js
@@ -23,3 +23,104 @@ State needed
 Props
   Not sure yet
 */
+import * as React from 'react';
+
+import Box from '@mui/material/Box';
+import { makeStyles } from '@mui/styles';
+import { SearchOutlined } from '@mui/icons-material'; // for when we need it, Search } from '@mui/icons-material';
+import TextField from '@mui/material/TextField';
+
+const useStyles = makeStyles((theme) => ({
+  SearchBox: {
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'flex-end',
+    backgroundColor: '#F8F9FA',
+    color: '#000000',
+    height: '48px',
+    borderRadius: theme.spacing(0.75),
+    '&:hover': {
+      backgroundColor: '#c5c6c7'
+    }
+  },
+  SearchBoxInput: {
+    color: '#000000'
+  },
+  SeachBoxIcon: {
+    color: '#000000',
+    margin: theme.spacing(1)
+  },
+  // root of the input is actually the div container for the text field
+  customTextField: {
+    cursor: 'pointer',
+    color: '#000000',
+    fontSize: '0.875rem',
+    fontWeight: '500',
+    // input
+    '& input': {
+      cursor: 'pointer',
+      color: '#000000',
+      fontSize: '0.875rem',
+      fontWeight: '500',
+      marginRight: theme.spacing(1),
+      marginBottom: theme.spacing(0.65),
+      paddingBottom: theme.spacing(0.25)
+    },
+    // input label
+    '& label': {
+      cursor: 'pointer',
+      color: '#000000',
+      fontSize: '0.875rem',
+      fontWeight: '500',
+      borderBottomColor: '#657A8E',
+      marginTop: theme.spacing(-0.5),
+      zIndex: '100'
+    },
+    // input label
+    '& label.MuiInputLabel-shrink': {
+      fontSize: '1rem',
+      fontWeight: '400',
+      color: '#657A8E',
+      marginTop: theme.spacing(0.5)
+    },
+    // input label with focus/typing search
+    '& label.Mui-focused': {
+      color: '#000000',
+      fontSize: '1rem',
+      fontWeight: '400',
+      marginTop: theme.spacing(0.5)
+    },
+    // input with focus/typing search
+    '& .Mui-focused input': {
+      cursor: 'text',
+      borderBottomColor: '#657A8E',
+      borderBottomWidth: '2px',
+      borderBottomStyle: 'solid',
+      marginBottom: '3px'
+    }
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function SearchCustom(props) {
+  const classes = useStyles();
+
+  return (
+    <Box p={0.75} >
+      <Box className={classes.SearchBox} >
+        <SearchOutlined className={classes.SeachBoxIcon}/>
+        <TextField
+          id="input-custom-search"
+          fullWidth
+          label="Search for a County or Watershed"
+          aria-label={'Search for a County or Watershed'}
+          variant="standard"
+          className={classes.customTextField}
+          InputProps={{ disableUnderline: true }}
+          InputLabelProps={{
+            className: classes.SearchBoxInput
+          }}/>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/Map/Upload.js
+++ b/src/components/Map/Upload.js
@@ -28,3 +28,39 @@ State needed
 Props
   - Not sure yet
 */
+import * as React from 'react';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import { makeStyles } from '@mui/styles';
+import {
+  FileUploadOutlined
+  // FileUpload
+} from '@mui/icons-material';
+
+const useStyles = makeStyles((theme) => ({
+  actionButton: {
+    height: theme.spacing(4.5),
+    textTransform: 'none',
+    justifyContent: 'start'
+  }
+}));
+
+// just a place holder needs props passed in and image etc
+export default function Upload(props) {
+  const classes = useStyles();
+
+  return (
+    <Box p={0.75} >
+      <Button
+        variant="contained"
+        color="CRESTPrimary"
+        fullWidth={true}
+        aria-label={'Upload Shapefile'}
+        className={classes.actionButton}
+        startIcon={<FileUploadOutlined />}>
+        Upload Shapefile
+      </Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
Adds buttons to the bottom of the map and the left side for adding areas, exporting the map, and toggling the display of the map layer list. The commit does not include any logic to do any of the actions. Also found an error with the `react-dom` version and will require an `npm install`.