### PR TITLE
Fix/attribution

### DIFF
--- a/src/components/Map/ActiveTileLayers.js
+++ b/src/components/Map/ActiveTileLayers.js
@@ -1,13 +1,37 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { TileLayer } from 'react-leaflet';
+import { updateAttributions } from '../../reducers/mapPropertiesSlice';
+
+const activeLayerListSelector = (state) => state.mapLayerList.activeLayerList;
+const attributionsSelector = (state) => state.mapProperties.attributions;
 
 export default function ActiveTileLayers() {
-  const activeLayerListSelector = (state) => state.mapLayerList.activeLayerList;
+  const dispatch = useDispatch();
+  const handleAttributionsChange = useCallback((newAttributions) => {
+    if (currAttributions.join(', ') !== newAttributions.join(', ')) {
+      console.log('mismatch!');
+      console.log(`${newAttributions} != ${currAttributions}`);
+      console.log('dispatching ' + newAttributions.join('') + ' to redux state');
+      dispatch(updateAttributions(newAttributions));
+    }
+  });
+  const currentAttributions = useSelector(attributionsSelector);
   const layerList = useSelector(activeLayerListSelector);
+  const layerAttributions = new Set(); // This should become redux State and read in BasemapLayer.js
+  const layers = Object.values(layerList).map((lyr) => {
+    layerAttributions.add(lyr.attribution);
+    return (<TileLayer key={lyr.id} url={lyr.url} opacity={lyr.opacity} pane={'overlayPane'} maxNativeZoom={lyr.maxNativeZoom} />
+    );
+  });
+  const currAttributions = [...currentAttributions].sort();
+  const newAttributions = Array.from(layerAttributions).sort();
 
+  useEffect(() => {
+    handleAttributionsChange(newAttributions);
+  }, [handleAttributionsChange, newAttributions]);
   return (
     // eslint-disable-next-line max-len
-    Object.values(layerList).map((lyr) => <TileLayer key={lyr.id} url={lyr.url} attribution={lyr.attribution} opacity={lyr.opacity} maxNativeZoom={lyr.maxNativeZoom}/>)
+    layers
   );
 }

--- a/src/components/Map/ActiveTileLayers.js
+++ b/src/components/Map/ActiveTileLayers.js
@@ -8,14 +8,14 @@ const attributionsSelector = (state) => state.mapProperties.attributions;
 
 export default function ActiveTileLayers() {
   const dispatch = useDispatch();
-  const handleAttributionsChange = useCallback((newAttributions) => {
-    if (currAttributions.join(', ') !== newAttributions.join(', ')) {
+  const handleAttributionsChange = useCallback((currAtts, newAtts) => {
+    if (currAtts.join(', ') !== newAtts.join(', ')) {
       console.log('mismatch!');
-      console.log(`${newAttributions} != ${currAttributions}`);
-      console.log('dispatching ' + newAttributions.join('') + ' to redux state');
-      dispatch(updateAttributions(newAttributions));
+      console.log(`${newAtts} != ${currAtts}`);
+      console.log('dispatching ', newAtts.join(''), ' to redux state');
+      dispatch(updateAttributions(newAtts));
     }
-  });
+  }, [dispatch]);
   const currentAttributions = useSelector(attributionsSelector);
   const layerList = useSelector(activeLayerListSelector);
   const layerAttributions = new Set(); // This should become redux State and read in BasemapLayer.js
@@ -28,8 +28,8 @@ export default function ActiveTileLayers() {
   const newAttributions = Array.from(layerAttributions).sort();
 
   useEffect(() => {
-    handleAttributionsChange(newAttributions);
-  }, [handleAttributionsChange, newAttributions]);
+    handleAttributionsChange(currAttributions, newAttributions);
+  }, [handleAttributionsChange, newAttributions, currAttributions]);
   return (
     // eslint-disable-next-line max-len
     layers

--- a/src/components/Map/ActiveTileLayers.js
+++ b/src/components/Map/ActiveTileLayers.js
@@ -31,7 +31,6 @@ export default function ActiveTileLayers() {
     handleAttributionsChange(currAttributions, newAttributions);
   }, [handleAttributionsChange, newAttributions, currAttributions]);
   return (
-    // eslint-disable-next-line max-len
     layers
   );
 }

--- a/src/components/Map/ActiveTileLayers.js
+++ b/src/components/Map/ActiveTileLayers.js
@@ -10,9 +10,6 @@ export default function ActiveTileLayers() {
   const dispatch = useDispatch();
   const handleAttributionsChange = useCallback((currAtts, newAtts) => {
     if (currAtts.join(', ') !== newAtts.join(', ')) {
-      console.log('mismatch!');
-      console.log(`${newAtts} != ${currAtts}`);
-      console.log('dispatching ', newAtts.join(''), ' to redux state');
       dispatch(updateAttributions(newAtts));
     }
   }, [dispatch]);

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -4,16 +4,45 @@ import React, {
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { vectorBasemapLayer } from 'esri-leaflet-vector';
+import { AttributionControl } from 'react-leaflet';
 import { mapConfig } from '../../configuration/config';
 
 const basemaps = mapConfig.basemaps;
 
 const baseMapSelector = (state) => state.mapProperties.basemap;
+const attributionsSelector = (state) => state.mapProperties.attributions;
 
 export default function BasemapLayer(props) {
   const { map } = props;
   const selectedBasemap = useSelector(baseMapSelector);
+  const selectedAttributions = useSelector(attributionsSelector);
+  const attributionString = useRef('');
   const basemapRef = useRef(null);
+  const handleAttributionsChange = useCallback((newAttributions) => {
+    // console.log('attributions change detected in basemap layer');
+    // console.log('selected attributions: ' + selectedAttributions);
+
+    // console.log('attributionString was ' + attributionString.current);
+    // console.log('size : ', selectedAttributions.length);
+    // if (map !== null) {
+    //   console.log(map);
+    //   map.attributionControl.addAttribution('sup');
+    // }
+    attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
+    // console.log('setting attributionString to ' + attributionString.current);
+    // if (basemapRef.current !== null) {
+      // basemapRef.current.options.attribution = attributionString.current;
+      // console.log('before: ', basemapRef.current.options);
+      // basemapRef.current.attribution = attributionString.current;
+      // basemapRef.current._setupAttribution();
+      // handleBasemapChange(basemapRef.current);
+      // console.log(basemapRef.current);
+      // map.attributionControl.addAttribution(basemapRef.current.attribution);
+    // }
+    // console.log(basemapRef.current);
+    // basemapRef.current.attribution = attributionString.current;
+  }, [selectedAttributions, map]);
+
   const handleBasemapChange = useCallback((basemapName) => {
     if (basemapRef.current !== null) {
       basemapRef.current.remove(map);
@@ -21,19 +50,24 @@ export default function BasemapLayer(props) {
     if (map) {
       const newBasemap = vectorBasemapLayer(basemaps[basemapName], {
         apikey: 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By',
-        pane: 'mapPane'
+        pane: 'mapPane',
+        attribution: attributionString.current // SHOULD PASS IN OUR SET FROM ACTIVE TILE LAYERS
       });
       newBasemap.addTo(map);
       basemapRef.current = newBasemap;
     }
-  }, [map, basemapRef]);
+  }, [map, basemapRef, attributionString]);
+
+  useEffect(() => {
+    handleAttributionsChange(selectedAttributions);
+  }, [handleAttributionsChange, selectedAttributions]);
 
   useEffect(() => {
     handleBasemapChange(selectedBasemap);
   }, [selectedBasemap, handleBasemapChange]);
 
   return (
-        <div></div>
+    <AttributionControl />
   );
 }
 

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -31,17 +31,17 @@ export default function BasemapLayer(props) {
     attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
     // console.log('setting attributionString to ' + attributionString.current);
     // if (basemapRef.current !== null) {
-      // basemapRef.current.options.attribution = attributionString.current;
-      // console.log('before: ', basemapRef.current.options);
-      // basemapRef.current.attribution = attributionString.current;
-      // basemapRef.current._setupAttribution();
-      // handleBasemapChange(basemapRef.current);
-      // console.log(basemapRef.current);
-      // map.attributionControl.addAttribution(basemapRef.current.attribution);
+    // basemapRef.current.options.attribution = attributionString.current;
+    // console.log('before: ', basemapRef.current.options);
+    // basemapRef.current.attribution = attributionString.current;
+    // basemapRef.current._setupAttribution();
+    // handleBasemapChange(basemapRef.current);
+    // console.log(basemapRef.current);
+    // map.attributionControl.addAttribution(basemapRef.current.attribution);
     // }
     // console.log(basemapRef.current);
     // basemapRef.current.attribution = attributionString.current;
-  }, [selectedAttributions, map]);
+  }, [selectedAttributions]);
 
   const handleBasemapChange = useCallback((basemapName) => {
     if (basemapRef.current !== null) {

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -28,7 +28,8 @@ export default function BasemapLayer(props) {
       const newBasemap = vectorBasemapLayer(basemaps[basemapName], {
         apikey: 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By',
         pane: 'mapPane',
-        attribution: attributionString.current
+        // attribution: attributionString.current
+        attribution: 'NFWF 2020, NFWF 2022'
       });
       newBasemap.addTo(map);
       basemapRef.current = newBasemap;
@@ -37,7 +38,7 @@ export default function BasemapLayer(props) {
 
   const handleAttributionsChange = useCallback(() => {
     attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
-    handleBasemapChange(selectedBasemap);
+    // handleBasemapChange(selectedBasemap);
   }, [handleBasemapChange, selectedAttributions, selectedBasemap]);
 
   useEffect(() => {

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -18,49 +18,31 @@ export default function BasemapLayer(props) {
   const selectedAttributions = useSelector(attributionsSelector);
   const attributionString = useRef('');
   const basemapRef = useRef(null);
-  const handleAttributionsChange = useCallback((newAttributions) => {
-    // console.log('attributions change detected in basemap layer');
-    // console.log('selected attributions: ' + selectedAttributions);
-
-    // console.log('attributionString was ' + attributionString.current);
-    // console.log('size : ', selectedAttributions.length);
-    // if (map !== null) {
-    //   console.log(map);
-    //   map.attributionControl.addAttribution('sup');
-    // }
-    attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
-    // console.log('setting attributionString to ' + attributionString.current);
-    // if (basemapRef.current !== null) {
-    // basemapRef.current.options.attribution = attributionString.current;
-    // console.log('before: ', basemapRef.current.options);
-    // basemapRef.current.attribution = attributionString.current;
-    // basemapRef.current._setupAttribution();
-    // handleBasemapChange(basemapRef.current);
-    // console.log(basemapRef.current);
-    // map.attributionControl.addAttribution(basemapRef.current.attribution);
-    // }
-    // console.log(basemapRef.current);
-    // basemapRef.current.attribution = attributionString.current;
-  }, [selectedAttributions]);
 
   const handleBasemapChange = useCallback((basemapName) => {
     if (basemapRef.current !== null) {
       basemapRef.current.remove(map);
     }
+
     if (map) {
       const newBasemap = vectorBasemapLayer(basemaps[basemapName], {
         apikey: 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By',
         pane: 'mapPane',
-        attribution: attributionString.current // SHOULD PASS IN OUR SET FROM ACTIVE TILE LAYERS
+        attribution: attributionString.current
       });
       newBasemap.addTo(map);
       basemapRef.current = newBasemap;
     }
   }, [map, basemapRef, attributionString]);
 
+  const handleAttributionsChange = useCallback(() => {
+    attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
+    handleBasemapChange(selectedBasemap);
+  }, [handleBasemapChange, selectedAttributions, selectedBasemap]);
+
   useEffect(() => {
-    handleAttributionsChange(selectedAttributions);
-  }, [handleAttributionsChange, selectedAttributions]);
+    handleAttributionsChange();
+  }, [handleAttributionsChange]);
 
   useEffect(() => {
     handleBasemapChange(selectedBasemap);

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -33,7 +33,7 @@ export default function BasemapLayer(props) {
       newBasemap.addTo(map);
       basemapRef.current = newBasemap;
     }
-  }, [map, basemapRef, attributionString]);
+  }, [map]);
 
   const handleAttributionsChange = useCallback(() => {
     attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';

--- a/src/reducers/mapPropertiesSlice.js
+++ b/src/reducers/mapPropertiesSlice.js
@@ -12,6 +12,7 @@ export const mapPropertiesSlice = createSlice({
     identifyResults: null,
     identifyIsLoaded: false,
     basemap: 'Dark Gray',
+    attributions: [],
     sketchArea: false,
     uploadedShapeFile: null,
     zonalStatsAreas: {
@@ -41,6 +42,9 @@ export const mapPropertiesSlice = createSlice({
     },
     changeBasemap: (state, action) => {
       state.basemap = action.payload;
+    },
+    updateAttributions: (state, action) => {
+      state.attributions = action.payload;
     },
     toggleSketchArea: (state) => {
       state.sketchArea = !state.sketchArea;
@@ -82,7 +86,7 @@ export const mapPropertiesSlice = createSlice({
 // Action creators are generated for each case reducer function
 export const {
   changeZoom, changeCenter, changeIdentifyCoordinates,
-  changeIdentifyResults, changeIdentifyIsLoaded, changeBasemap,
+  changeIdentifyResults, changeIdentifyIsLoaded, changeBasemap, updateAttributions,
   toggleSketchArea, addNewFeatureToZonalStatsAreas, removeAllFeaturesFromZonalStatsAreas,
   removeFeatureFromZonalStatsAreas, addNewFeatureToDrawnLayers, removeFeatureFromDrawnLayers,
   removeAllFeaturesFromDrawnLayers, uploadShapeFile


### PR DESCRIPTION
This fixes the attribution issue caused by adding/removing layers.  Before this PR, when selecting a data layer, the basemap attributions were being overwritten/replaced by the layer attributions.  This PR combines attributions so that both basemap and additional layer attributions are displayed.