### PR TITLE
fixes lint errors

### DIFF
--- a/src/components/All/ModalShare.js
+++ b/src/components/All/ModalShare.js
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import Paper from '@mui/material/Paper';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+
+export default function ModalShare(props) {
+  const {
+    contentTitle,
+    buttonMessage,
+    secondaryButtonMessage,
+    onClose,
+    onDoubleClick,
+    secondaryClick,
+    open
+  } = props;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle>{contentTitle}</DialogTitle>
+      <DialogContent>
+        <Paper
+          onDoubleClick={onDoubleClick}
+          variant="outlined"
+          square={false}
+          sx={{
+            padding: '20px',
+            backgroundColor: 'CRESTDarkAlt.main',
+            color: 'CRESTDarkAlt.contrastText',
+            borderColor: 'CRESTBorderColor.main'
+          }} >
+          {props.contentMessage}
+        </Paper>
+      </DialogContent>
+      <DialogActions>
+        <Button
+              variant="contained"
+              color="CRESTDarkAlt"
+              aria-label="Copy"
+              onClick={secondaryClick}
+              endIcon={<ContentPasteIcon />}>
+              {secondaryButtonMessage}
+        </Button>
+        <Button
+          variant="contained"
+          color="CRESTPrimary"
+          onClick={onClose}
+          autoFocus>
+          {buttonMessage}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+ModalShare.propTypes = {
+  contentTitle: PropTypes.string,
+  contentMessage: PropTypes.string,
+  buttonMessage: PropTypes.string,
+  secondaryButtonMessage: PropTypes.string,
+  onClose: PropTypes.func,
+  onDoubleClick: PropTypes.func,
+  secondaryClick: PropTypes.func,
+  open: PropTypes.bool
+};

--- a/src/components/All/ModelErrors.js
+++ b/src/components/All/ModelErrors.js
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
 
-export default function DialogPopup(props) {
+export default function ModelErrors(props) {
+  // errorType = error, warning, info, success (https://mui.com/material-ui/react-alert/)
+
   const {
     contentTitle,
-    contentMessage,
     buttonMessage,
+    errorType,
     onClose,
     open
   } = props;
@@ -25,12 +27,14 @@ export default function DialogPopup(props) {
     >
       <DialogTitle>{contentTitle}</DialogTitle>
       <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          {contentMessage}
-        </DialogContentText>
+        <Alert severity={errorType}>{props.contentMessage}</Alert>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose} autoFocus>
+        <Button
+          onClick={onClose}
+          variant="contained"
+          color="CRESTPrimary"
+          autoFocus>
           {buttonMessage}
         </Button>
       </DialogActions>
@@ -38,10 +42,11 @@ export default function DialogPopup(props) {
   );
 }
 
-DialogPopup.propTypes = {
+ModelErrors.propTypes = {
   contentTitle: PropTypes.string,
   contentMessage: PropTypes.string,
   buttonMessage: PropTypes.string,
+  errorType: PropTypes.string,
   onClose: PropTypes.func,
   open: PropTypes.bool
 };

--- a/src/components/Map/Identify.js
+++ b/src/components/Map/Identify.js
@@ -37,9 +37,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
+import { IconButton } from '@mui/material/';
 import Grid from '@mui/material/Grid';
 import { makeStyles } from '@mui/styles';
 import Typography from '@mui/material/Typography';
+import CancelIcon from '@mui/icons-material/Cancel';
 
 import {
   changeIdentifyCoordinates,
@@ -101,6 +103,25 @@ const useStyles = makeStyles((theme) => ({
       color: `${theme.palette.CRESTLight.contrastText} !important`
     }
   },
+  titleBoxTypography: {
+    cursor: 'default',
+    display: 'flex',
+    width: '100%',
+    fontWeight: 'bold'
+  },
+  titleBox: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '54px',
+    paddingBottom: theme.spacing(0.5)
+  },  
+  rightActionButton: {
+    height: theme.spacing(4.5),
+    padding: theme.spacing(0.375),
+    justifyContent: 'end'      
+  },
   valueName: {
     display: 'flex',
     justifyContent: 'center',
@@ -155,10 +176,20 @@ export default function ShowIdentifyPopup(props) {
             className={classes.indentifyPopup}
             closeButton={false}
           >
-            <Typography variant="h6" component="div" align="center" gutterBottom>
-              Map Information
-              <button onClick={closePopups}>Close</button>
-            </Typography>
+            
+            <Box px={1} py={0.75} className={classes.titleBox}>
+              <Typography px={1} variant="h6" component="div" className={classes.titleBoxTypography} >
+                Map Information
+              </Typography>
+              <IconButton
+                  variant="contained"
+                  color="CRESTPrimary"
+                  className={classes.rightActionButton}
+                  aria-label="Close"
+                  onClick={closePopups}>
+                  <CancelIcon />
+                </IconButton>
+            </Box>
             <Divider />
             <Grid container spaceing={2} justifyContent="start" alignItems="start" pt={1.5}>
               <Grid item xs={12}>
@@ -186,10 +217,19 @@ export default function ShowIdentifyPopup(props) {
         closeButton={false}
         className={classes.indentifyPopup}
       >
-        <Typography variant="h6" component="div" align="center" gutterBottom>
-          Map Information
-          <button onClick={closePopups}>Close</button>
-        </Typography>
+        <Box px={1} py={0.75} className={classes.titleBox}>
+          <Typography px={1} variant="h6" component="div" className={classes.titleBoxTypography} >
+            Map Information
+          </Typography>
+          <IconButton
+              variant="contained"
+              color="CRESTPrimary"
+              className={classes.rightActionButton}
+              aria-label="Close"
+              onClick={closePopups}>
+              <CancelIcon />
+            </IconButton>
+        </Box>
         <Divider />
         <Grid container spaceing={2} pt={2} alignItems="center" justifyContent="center">
           <Grid item xs={12}>

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -46,6 +46,7 @@ import {
   // Polygon
 } from 'react-leaflet';
 import InfoIcon from '@mui/icons-material/Info';
+import ShareIcon from '@mui/icons-material/Share';
 import { makeStyles } from '@mui/styles';
 import { Button } from '@mui/material';
 import Control from 'react-leaflet-custom-control';
@@ -63,7 +64,9 @@ import ShowIdentifyPopup from './Identify';
 import { mapConfig } from '../../configuration/config';
 import ActionButtons from './ActionButtons';
 import { createShareURL } from './ShareMap';
-import DialogPopup from '../All/DialogPopup';
+import ModelErrors from '../All/ModelErrors';
+import ModalShare from '../All/ModalShare';
+
 // import Boxforlayout from './BoxForLayouts';
 
 const regions = mapConfig.regions;
@@ -82,17 +85,6 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '30px',
     minWidth: '30px',
     width: '30px',
-    height: '30px',
-    backgroundColor: '#FFFFFF',
-    '&:hover': {
-      backgroundColor: '#F4F4F4'
-    }
-  },
-  shareButton: {
-    color: '#000000',
-    minHeight: '30px',
-    minWidth: '60px',
-    width: '60px',
     height: '30px',
     backgroundColor: '#FFFFFF',
     '&:hover': {
@@ -157,7 +149,6 @@ export default function MapCard(props) {
     }
   }, [map, layerListVisible]);
 
-
   useEffect(() => {
     handleRegionChange(selectedRegion, userInitiatedRegion);
   }, [selectedRegion, handleRegionChange, userInitiatedRegion]);
@@ -196,16 +187,28 @@ export default function MapCard(props) {
     });
   };
 
-  const handleShareLinkClose = () => {
-    // navigator.clipboard.writeText(shareUrl); THIS IS BROKEN ON HTTP
+  const handleShareLinkClose = (event) => {
+    // navigator.clipboard.writeText(shareUrl); // THIS IS BROKEN ON HTTP
     setShareLinkOpen(false);
+  };
+
+  const handleShareLinkCopy = () => {
+    navigator.clipboard.writeText(shareUrl); // THIS IS BROKEN ON HTTP
   };
 
   const handleTooLargeLayerClose = () => {
     setTooLargeLayerOpen(false);
   };
 
-  const shareMapHandler = () => {
+  const handleSelectURLDblClick = (event) => {
+    const range = document.createRange();
+    range.selectNodeContents(event.target);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(range);
+  };
+
+  const shareMapHandler = (event) => {
+    event.stopPropagation();
     setShareUrl(createShareURL());
     setShareLinkOpen(true);
   };
@@ -224,9 +227,11 @@ export default function MapCard(props) {
         <Control prepend='true' position='bottomleft'>
           <Button
             variant="contained"
+            startIcon={<ShareIcon />}
             onClick={shareMapHandler}
+            color="CRESTPrimary"
             className={classes.shareButton}>
-            SHARE
+            Share Map
           </Button>
         </Control>
         <LayersControl position="topright">
@@ -242,15 +247,21 @@ export default function MapCard(props) {
             </FeatureGroup>
           </LayersControl.Overlay>
         </LayersControl>
-        <DialogPopup
-          contentMessage={('Your Share URL is: ').concat(shareUrl)}
+        <ModalShare
+          contentTitle={'Share map url'}
+          contentMessage={shareUrl}
           buttonMessage='Dismiss'
           onClose={handleShareLinkClose}
+          onDoubleClick={handleSelectURLDblClick}
+          secondaryClick={handleShareLinkCopy}
+          secondaryButtonMessage='Copy Map URL'
           open={shareLinkOpen}
         />
-        <DialogPopup
-          contentMessage={'Layer is too large.'}
+        <ModelErrors
+          contentTitle={'Sketch an Area Error '}
+          contentMessage={'The sketched area is too large.'}
           buttonMessage='Dismiss'
+          errorType={'error'} // error, warning, info, success (https://mui.com/material-ui/react-alert/)
           onClose={handleTooLargeLayerClose}
           open={tooLargeLayerOpen}
         />

--- a/src/components/Map/ShareMap.js
+++ b/src/components/Map/ShareMap.js
@@ -20,7 +20,7 @@ Props
 */
 import { useDispatch } from 'react-redux';
 import { v4 } from 'uuid';
-import { betaShareLinkEndpoint, prodShareLinkEndpoint } from '../../configuration/config';
+import { betaShareLinkEndpoint } from '../../configuration/config';
 import {
   changeZoom, changeCenter, changeIdentifyCoordinates,
   changeIdentifyResults, changeIdentifyIsLoaded

--- a/src/configuration/regions/alaska.js
+++ b/src/configuration/regions/alaska.js
@@ -399,15 +399,15 @@ export const alaskaConfig = {
       chartLegendValues: 5,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#0084A8', 
-        2: '#0084A8', 
-        3: '#0084A8', 
+        1: '#0084A8',
+        2: '#0084A8',
+        3: '#0084A8',
         4: '#0084A8',
-        5: '#0084A8' 
+        5: '#0084A8'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        5: '#0084A8' 
+        5: '#0084A8'
       },
       url: 'https://tiles.resilientcoasts.org/AK_CriticalFacilitiesIndexTiles/{z}/{x}/{y}.png',
       attribution: 'NFWF 2022',
@@ -426,15 +426,15 @@ export const alaskaConfig = {
       chartLegendValues: 5,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#A82B41', 
-        2: '#A82B41', 
-        3: '#A82B41', 
-        4: '#A82B41', 
-        5: '#A82B41' 
+        1: '#A82B41',
+        2: '#A82B41',
+        3: '#A82B41',
+        4: '#A82B41',
+        5: '#A82B41'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        5: '#A82B41' 
+        5: '#A82B41'
       },
       url: 'https://tiles.resilientcoasts.org/AK_CommunityInfrastructurIndexTiles/{z}/{x}/{y}.png',
       attribution: 'NFWF 2022',
@@ -453,15 +453,15 @@ export const alaskaConfig = {
       chartLegendValues: 5,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#FEB24C', 
-        2: '#FEB24C', 
-        3: '#FEB24C', 
-        4: '#FEB24C', 
-        5: '#FEB24C' 
+        1: '#FEB24C',
+        2: '#FEB24C',
+        3: '#FEB24C',
+        4: '#FEB24C',
+        5: '#FEB24C'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        5: '#FEB24C' 
+        5: '#FEB24C'
       },
       url: 'https://tiles.resilientcoasts.org/AK_TransporationInfrastructure/{z}/{x}/{y}.png',
       attribution: 'NFWF 2022',
@@ -542,13 +542,13 @@ export const alaskaConfig = {
       chartLegendValues: 5,
       chartCSSColor: {
         0: '#E9ECEF',
-        3: '#FB6A4A', 
+        3: '#FB6A4A',
         4: '#DE2D26',
         5: '#A50F15'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        3: '#FB6A4A', 
+        3: '#FB6A4A',
         4: '#DE2D26',
         5: '#A50F15'
       },

--- a/src/configuration/regions/american_samoa.js
+++ b/src/configuration/regions/american_samoa.js
@@ -375,7 +375,7 @@ export const americanSamoaConfig = {
       chartCSSSelector: 'social_vuln',
       chartCSSLegends: {
         0: '#E9ECEF',
-        1: '#88419D',
+        1: '#88419D'
       },
       url: 'https://tiles.resilientcoasts.org/AS_SocVulnIndexTiles/{z}/{x}/{y}.png',
       attribution: 'NFWF 2020',
@@ -392,15 +392,15 @@ export const americanSamoaConfig = {
       chartLegendValues: 5,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#0084A8', 
-        2: '#0084A8', 
-        3: '#0084A8', 
-        4: '#0084A8', 
-        5: '#0084A8' 
+        1: '#0084A8',
+        2: '#0084A8',
+        3: '#0084A8',
+        4: '#0084A8',
+        5: '#0084A8'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        5: '#0084A8' 
+        5: '#0084A8'
       },
       ChartInputLabel: 'Community Assets Inputs',
       chartCSSSelector: 'crit_facilities',
@@ -419,29 +419,29 @@ export const americanSamoaConfig = {
       chartLegendValues: 15,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#CCD1D2', 
-        2: '#CCD1D2', 
-        3: '#CCD1D2', 
-        4: '#355C59', 
-        5: '#355C59', 
-        6: '#355C59', 
-        7: '#E8B16D', 
-        8: '#E8B16D', 
-        9: '#E8B16D',  
-        10: '#AD3541', 
-        11: '#AD3541', 
-        12: '#AD3541', 
-        13: '#7B1733', 
-        14: '#7B1733', 
-        15: '#7B1733' 
+        1: '#CCD1D2',
+        2: '#CCD1D2',
+        3: '#CCD1D2',
+        4: '#355C59',
+        5: '#355C59',
+        6: '#355C59',
+        7: '#E8B16D',
+        8: '#E8B16D',
+        9: '#E8B16D',
+        10: '#AD3541',
+        11: '#AD3541',
+        12: '#AD3541',
+        13: '#7B1733',
+        14: '#7B1733',
+        15: '#7B1733'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        3: '#CCD1D2', 
-        5: '#355C59', 
-        8: '#E8B16D', 
-        10: '#AD3541', 
-        15: '#7B1733' 
+        3: '#CCD1D2',
+        5: '#355C59',
+        8: '#E8B16D',
+        10: '#AD3541',
+        15: '#7B1733'
       },
       ChartInputLabel: 'Community Assets Inputs',
       chartCSSSelector: 'crit_infra',
@@ -460,18 +460,18 @@ export const americanSamoaConfig = {
       chartLegendValues: 6,
       chartCSSColor: {
         0: '#E9ECEF',
-        1: '#447604', 
-        2: '#447604', 
-        3: '#DCE9F2', 
-        4: '#DCE9F2', 
-        5: '#553555', 
-        6: '#553555' 
+        1: '#447604',
+        2: '#447604',
+        3: '#DCE9F2',
+        4: '#DCE9F2',
+        5: '#553555',
+        6: '#553555'
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        1: '#447604', 
+        1: '#447604',
         3: '#DCE9F2',
-        5: '#553555' 
+        5: '#553555'
       },
       ChartInputLabel: 'Threats Inputs',
       chartCSSSelector: 'impermeable',
@@ -650,7 +650,7 @@ export const americanSamoaConfig = {
       },
       chartCSSLegends: {
         0: '#E9ECEF',
-        3: '#2171b5',
+        3: '#2171b5'
       },
       ChartInputLabel: 'Threats Inputs',
       chartCSSSelector: 'tsunami',

--- a/src/configuration/regions/continental_us.js
+++ b/src/configuration/regions/continental_us.js
@@ -372,11 +372,11 @@ export const continentalUSConfig = {
           2: '#0084a8',
           3: '#0084a8',
           4: '#0084a8',
-          5: '#0084a8' 
+          5: '#0084a8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          5: '#0084a8' 
+          5: '#0084a8'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',

--- a/src/configuration/regions/guam.js
+++ b/src/configuration/regions/guam.js
@@ -418,15 +418,15 @@ export const guamConfig = {
         chartLegendValues: 5,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#0084A8', 
-          2: '#0084A8', 
-          3: '#0084A8', 
-          4: '#0084A8', 
-          5: '#0084A8' 
+          1: '#0084A8',
+          2: '#0084A8',
+          3: '#0084A8',
+          4: '#0084A8',
+          5: '#0084A8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          5: '#0084A8' 
+          5: '#0084A8'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',
@@ -447,29 +447,29 @@ export const guamConfig = {
         chartLegendValues: 15,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#CCD1D2', 
-          2: '#CCD1D2', 
-          3: '#CCD1D2', 
-          4: '#355C59', 
-          5: '#355C59', 
-          6: '#355C59', 
-          7: '#E8B16D', 
-          8: '#E8B16D', 
-          9: '#E8B16D', 
-          10: '#AD3541', 
-          11: '#AD3541', 
-          12: '#AD3541', 
-          13: '#7B1733', 
-          14: '#7B1733', 
-          15: '#7B1733' 
+          1: '#CCD1D2',
+          2: '#CCD1D2',
+          3: '#CCD1D2',
+          4: '#355C59',
+          5: '#355C59',
+          6: '#355C59',
+          7: '#E8B16D',
+          8: '#E8B16D',
+          9: '#E8B16D',
+          10: '#AD3541',
+          11: '#AD3541',
+          12: '#AD3541',
+          13: '#7B1733',
+          14: '#7B1733',
+          15: '#7B1733'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
           3: '#CCD1D2',
-          5: '#355C59', 
-          8: '#E8B16D', 
-          10: '#AD3541', 
-          15: '#7B1733' 
+          5: '#355C59',
+          8: '#E8B16D',
+          10: '#AD3541',
+          15: '#7B1733'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',
@@ -490,18 +490,18 @@ export const guamConfig = {
         chartLegendValues: 6,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#447604', 
-          2: '#447604', 
-          3: '#DCE9F2', 
-          4: '#DCE9F2', 
-          5: '#553555', 
-          6: '#553555' 
+          1: '#447604',
+          2: '#447604',
+          3: '#DCE9F2',
+          4: '#DCE9F2',
+          5: '#553555',
+          6: '#553555'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          1: '#447604', 
-          3: '#DCE9F2', 
-          5: '#553555',
+          1: '#447604',
+          3: '#DCE9F2',
+          5: '#553555'
         },
         chartInputName: 'threat',
         ChartInputLabel: 'Threats Inputs',

--- a/src/configuration/regions/hawaii.js
+++ b/src/configuration/regions/hawaii.js
@@ -367,17 +367,17 @@ export const hawaiiConfig = {
         chartLegendValues: 6,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#9EBBD7', 
-          2: '#9EBBD7', 
-          3: '#9EBBD7', 
-          4: '#0084A8', 
-          5: '#0084A8', 
-          6: '#0084A8' 
+          1: '#9EBBD7',
+          2: '#9EBBD7',
+          3: '#9EBBD7',
+          4: '#0084A8',
+          5: '#0084A8',
+          6: '#0084A8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          3: '#9EBBD7', 
-          5: '#0084A8', 
+          3: '#9EBBD7',
+          5: '#0084A8'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',
@@ -472,7 +472,7 @@ export const hawaiiConfig = {
           3: '#f07818',
           4: '#b84203',
           5: '#662506'
-        },        
+        },
         chartCSSLegends: {
           0: '#E9ECEF',
           1: '#feeba2',

--- a/src/configuration/regions/northern_mariana_islands.js
+++ b/src/configuration/regions/northern_mariana_islands.js
@@ -367,16 +367,16 @@ export const northernMarianaIslandsConfig = {
         chartLegendValues: 6,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#9EBBD7', 
-          2: '#9EBBD7', 
-          3: '#9EBBD7', 
-          4: '#0084A8', 
-          5: '#0084A8', 
-          6: '#0084A8' 
+          1: '#9EBBD7',
+          2: '#9EBBD7',
+          3: '#9EBBD7',
+          4: '#0084A8',
+          5: '#0084A8',
+          6: '#0084A8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          3: '#9EBBD7', 
+          3: '#9EBBD7',
           5: '#0084A8'
         },
         chartInputName: 'asset',

--- a/src/configuration/regions/puertoRico.js
+++ b/src/configuration/regions/puertoRico.js
@@ -367,17 +367,17 @@ export const puertoRicoConfig = {
         chartLegendValues: 6,
         chartCSSColor: {
           0: '#E9ECEF',
-          1: '#9EBBD7', 
-          2: '#9EBBD7', 
-          3: '#9EBBD7', 
-          4: '#0084A8', 
-          5: '#0084A8', 
-          6: '#0084A8' 
+          1: '#9EBBD7',
+          2: '#9EBBD7',
+          3: '#9EBBD7',
+          4: '#0084A8',
+          5: '#0084A8',
+          6: '#0084A8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          3: '#9EBBD7', 
-          5: '#0084A8', 
+          3: '#9EBBD7',
+          5: '#0084A8'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',
@@ -568,7 +568,7 @@ export const puertoRicoConfig = {
           3: '#4bb062',
           4: '#157f3b',
           5: '#00441b'
-        },        
+        },
         chartCSSLegends: {
           0: '#E9ECEF',
           1: '#d3eecd',

--- a/src/configuration/regions/usVirginIslands.js
+++ b/src/configuration/regions/usVirginIslands.js
@@ -371,12 +371,12 @@ export const usVirginIslandsConfig = {
           2: '#0084a8',
           3: '#0084a8',
           4: '#0084a8',
-          5: '#0084a8', 
-          6: '#0084a8' 
+          5: '#0084a8',
+          6: '#0084a8'
         },
         chartCSSLegends: {
           0: '#E9ECEF',
-          5: '#0084a8', 
+          5: '#0084a8'
         },
         chartInputName: 'asset',
         ChartInputLabel: 'Community Assets Inputs',


### PR DESCRIPTION
Styled Identify close button.

Styled popups for the share map also added a new dialog to handle errors. Created two different dialogs: one for errors and one for share map.

The error dialog uses an error type from https://mui.com/material-ui/react-alert to handle error text color and icons into four categories error, warning, info, and success.

@jeffbliss and @seanebum There are still many lint errors - but I want to avoid causing conflicts in areas you all are working on, but we should run the `lint-test` to ensure we are following our lint rules.