### PR TITLE
fix attribution from hard-code -> region-selected

### DIFF
--- a/src/components/Map/ActiveTileLayers.js
+++ b/src/components/Map/ActiveTileLayers.js
@@ -1,32 +1,14 @@
-import React, { useEffect, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React from 'react';
+import { useSelector } from 'react-redux';
 import { TileLayer } from 'react-leaflet';
-import { updateAttributions } from '../../reducers/mapPropertiesSlice';
 
 const activeLayerListSelector = (state) => state.mapLayerList.activeLayerList;
-const attributionsSelector = (state) => state.mapProperties.attributions;
 
 export default function ActiveTileLayers() {
-  const dispatch = useDispatch();
-  const handleAttributionsChange = useCallback((currAtts, newAtts) => {
-    if (currAtts.join(', ') !== newAtts.join(', ')) {
-      dispatch(updateAttributions(newAtts));
-    }
-  }, [dispatch]);
-  const currentAttributions = useSelector(attributionsSelector);
   const layerList = useSelector(activeLayerListSelector);
-  const layerAttributions = new Set(); // This should become redux State and read in BasemapLayer.js
-  const layers = Object.values(layerList).map((lyr) => {
-    layerAttributions.add(lyr.attribution);
-    return (<TileLayer key={lyr.id} url={lyr.url} opacity={lyr.opacity} pane={'overlayPane'} maxNativeZoom={lyr.maxNativeZoom} />
-    );
-  });
-  const currAttributions = [...currentAttributions].sort();
-  const newAttributions = Array.from(layerAttributions).sort();
+  const layers = Object.values(layerList).map((lyr) => (<TileLayer key={lyr.id} url={lyr.url} opacity={lyr.opacity} pane={'overlayPane'} maxNativeZoom={lyr.maxNativeZoom} />
+  ));
 
-  useEffect(() => {
-    handleAttributionsChange(currAttributions, newAttributions);
-  }, [handleAttributionsChange, newAttributions, currAttributions]);
   return (
     layers
   );

--- a/src/components/Map/BasemapLayer.js
+++ b/src/components/Map/BasemapLayer.js
@@ -8,15 +8,15 @@ import { AttributionControl } from 'react-leaflet';
 import { mapConfig } from '../../configuration/config';
 
 const basemaps = mapConfig.basemaps;
+const regions = mapConfig.regions;
 
 const baseMapSelector = (state) => state.mapProperties.basemap;
-const attributionsSelector = (state) => state.mapProperties.attributions;
+const selectedRegionSelector = (state) => state.selectedRegion.value;
 
 export default function BasemapLayer(props) {
   const { map } = props;
   const selectedBasemap = useSelector(baseMapSelector);
-  const selectedAttributions = useSelector(attributionsSelector);
-  const attributionString = useRef('');
+  const selectedRegion = useSelector(selectedRegionSelector);
   const basemapRef = useRef(null);
 
   const handleBasemapChange = useCallback((basemapName) => {
@@ -28,22 +28,12 @@ export default function BasemapLayer(props) {
       const newBasemap = vectorBasemapLayer(basemaps[basemapName], {
         apikey: 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By',
         pane: 'mapPane',
-        // attribution: attributionString.current
-        attribution: 'NFWF 2020, NFWF 2022'
+        attribution: regions[selectedRegion].attribution
       });
       newBasemap.addTo(map);
       basemapRef.current = newBasemap;
     }
-  }, [map]);
-
-  const handleAttributionsChange = useCallback(() => {
-    attributionString.current = selectedAttributions.length > 0 ? Array.from(selectedAttributions).join(', ') : '';
-    // handleBasemapChange(selectedBasemap);
-  }, [handleBasemapChange, selectedAttributions, selectedBasemap]);
-
-  useEffect(() => {
-    handleAttributionsChange();
-  }, [handleAttributionsChange]);
+  }, [map, selectedRegion]);
 
   useEffect(() => {
     handleBasemapChange(selectedBasemap);

--- a/src/configuration/regions/alaska.js
+++ b/src/configuration/regions/alaska.js
@@ -7,6 +7,7 @@ export const alaskaConfig = {
     extent: [-185.977, 46.073, -95.801, 73.751],
     zoom: 4
   },
+  attribution: 'NFWF 2022',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/american_samoa.js
+++ b/src/configuration/regions/american_samoa.js
@@ -7,6 +7,7 @@ export const americanSamoaConfig = {
     extent: [-170.88, -14.71, -168.92, -13.90],
     zoom: 9
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/continental_us.js
+++ b/src/configuration/regions/continental_us.js
@@ -7,6 +7,7 @@ export const continentalUSConfig = {
     extent: [-132.97, 25.16, -62.49, 50.00],
     zoom: 4
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/guam.js
+++ b/src/configuration/regions/guam.js
@@ -7,6 +7,7 @@ export const guamConfig = {
     extent: [144.33, 13.20, 145.88, 13.79],
     zoom: 10
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/hawaii.js
+++ b/src/configuration/regions/hawaii.js
@@ -7,6 +7,7 @@ export const hawaiiConfig = {
     extent: [-166.09, 13.77, -140.36, 26.78],
     zoom: 6
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/northern_mariana_islands.js
+++ b/src/configuration/regions/northern_mariana_islands.js
@@ -7,6 +7,7 @@ export const northernMarianaIslandsConfig = {
     extent: [144.87, 13.92, 147.27, 15.38],
     zoom: 9
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/puertoRico.js
+++ b/src/configuration/regions/puertoRico.js
@@ -7,6 +7,7 @@ export const puertoRicoConfig = {
     extent: [-67.54431130541467, 17.46071271042981, -65.08612038744593, 18.895892559415024],
     zoom: 8
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/configuration/regions/usVirginIslands.js
+++ b/src/configuration/regions/usVirginIslands.js
@@ -7,6 +7,7 @@ export const usVirginIslandsConfig = {
     extent: [-65.13508888306899, 17.627008270947076, -64.25480934205336, 18.46267598832466],
     zoom: 10
   },
+  attribution: 'NFWF 2020',
   chartInputs: [
     {
       chartInputName: 'summary',

--- a/src/reducers/mapPropertiesSlice.js
+++ b/src/reducers/mapPropertiesSlice.js
@@ -12,7 +12,6 @@ export const mapPropertiesSlice = createSlice({
     identifyResults: null,
     identifyIsLoaded: false,
     basemap: 'Dark Gray',
-    attributions: [],
     sketchArea: false,
     uploadedShapeFile: null,
     zonalStatsAreas: {
@@ -42,9 +41,6 @@ export const mapPropertiesSlice = createSlice({
     },
     changeBasemap: (state, action) => {
       state.basemap = action.payload;
-    },
-    updateAttributions: (state, action) => {
-      state.attributions = action.payload;
     },
     toggleSketchArea: (state) => {
       state.sketchArea = !state.sketchArea;
@@ -86,7 +82,7 @@ export const mapPropertiesSlice = createSlice({
 // Action creators are generated for each case reducer function
 export const {
   changeZoom, changeCenter, changeIdentifyCoordinates,
-  changeIdentifyResults, changeIdentifyIsLoaded, changeBasemap, updateAttributions,
+  changeIdentifyResults, changeIdentifyIsLoaded, changeBasemap,
   toggleSketchArea, addNewFeatureToZonalStatsAreas, removeAllFeaturesFromZonalStatsAreas,
   removeFeatureFromZonalStatsAreas, addNewFeatureToDrawnLayers, removeFeatureFromDrawnLayers,
   removeAllFeaturesFromDrawnLayers, uploadedShapeFileGeoJSON


### PR DESCRIPTION
rewire attributions for NFWF data to be pulled in on REGION selection rather than LAYER selection.  Currently, all layers for a region have the same attribution anyways, and re-rendering the basemap for each change of layer does not look good.  Hopefully this is a decent middle ground.  The changes in this PR include the removal of the redux/state linkage for handling attributions with each layer, and just updates the basemap change callback to re-render the basemap on region change (in order to draw in the new region's attributions). 

I also moved the "attributions" in config from each layer in the layer list to the top level for each region to make that attribution selection simpler.