### PR TITLE
Highlight areas

### DIFF
--- a/src/components/AnalyzeArea/AnalyzeAreaHolder.js
+++ b/src/components/AnalyzeArea/AnalyzeAreaHolder.js
@@ -63,4 +63,5 @@ AnalyzeAreaHolder.propTypes = {
   boxHeight: PropTypes.string.isRequired,
   boxMarginTop: PropTypes.string,
   leafletDrawFeatureGroupRef: PropTypes.object,
+  map: PropTypes.object
 };

--- a/src/components/AnalyzeArea/AnalyzeAreaHolder.js
+++ b/src/components/AnalyzeArea/AnalyzeAreaHolder.js
@@ -40,6 +40,7 @@ export default function AnalyzeAreaHolder(props) {
     boxHeight,
     boxMarginTop,
     leafletDrawFeatureGroupRef,
+    map
   } = props;
   const analyzeAreaState = useSelector(AnalyzeAreaSelector);
 
@@ -51,6 +52,7 @@ export default function AnalyzeAreaHolder(props) {
         <ChartsHolder
           boxHeight={boxHeight}
           leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+          map={map}
         />
       )}
     </Box>

--- a/src/components/AnalyzeArea/ChartActionButtons.js
+++ b/src/components/AnalyzeArea/ChartActionButtons.js
@@ -40,7 +40,6 @@ import {
   CenterFocusStrong
 } from '@mui/icons-material';
 
-import { map } from 'leaflet';
 import { changeMore } from '../../reducers/analyzeAreaSlice';
 import {
   removeFeatureFromZonalStatsAreas, removeFeatureFromDrawnLayers,
@@ -81,7 +80,7 @@ export default function ChartActionButtons(props) {
   const selectedRegion = useSelector(selectedRegionSelector);
   const drawnLayers = useSelector(drawnLayersSelector);
 
-  function calculateZoomLevel(latRange, longRange) { 
+  function calculateZoomLevel(latRange, longRange) {
     // Define the size of the map container in pixels
     const mapSize = [600, 400];
 
@@ -116,6 +115,7 @@ export default function ChartActionButtons(props) {
           longMin = y < longMin ? y : longMin;
           latSum += x;
           longSum += y;
+          return true;
         });
         const latRange = latMax - latMin;
         const longRange = longMax - longMin;
@@ -128,6 +128,7 @@ export default function ChartActionButtons(props) {
         dispatch(changeZoom(newZoom));
         map.setView(newCenter, newZoom);
       }
+      return true;
     });
   };
 
@@ -248,5 +249,6 @@ ChartActionButtons.propTypes = {
   areaIndex: PropTypes.number.isRequired,
   data: PropTypes.object,
   leafletDrawFeatureGroupRef: PropTypes.object,
-  leafletIds: PropTypes.array
+  leafletIds: PropTypes.array,
+  map: PropTypes.object
 };

--- a/src/components/AnalyzeArea/ChartActionButtons.js
+++ b/src/components/AnalyzeArea/ChartActionButtons.js
@@ -81,20 +81,48 @@ export default function ChartActionButtons(props) {
   const selectedRegion = useSelector(selectedRegionSelector);
   const drawnLayers = useSelector(drawnLayersSelector);
 
+  function calculateZoomLevel(latRange, longRange) { 
+    // Define the size of the map container in pixels
+    const mapSize = [600, 400];
+
+    // Define the maximum zoom level
+    const maxZoom = 18;
+
+    // Define the scale factor to adjust the zoom level
+    const scaleFactor = 0.9;
+
+    // Calculate the zoom level based on the lat and long ranges and map size
+    const zoomLat = Math.log(mapSize[1] / latRange) / Math.LN2;
+    const zoomLong = Math.log(mapSize[0] / longRange) / Math.LN2;
+    const zoom = Math.floor(Math.min(zoomLat, zoomLong, maxZoom) * scaleFactor);
+
+    return zoom;
+  }
+
   const handleZoomClick = (event) => {
     event.stopPropagation();
     drawnLayers.features.map((feature) => {
-      let xSum = 0;
-      let ySum = 0;
+      let latSum = 0;
+      let longSum = 0;
+      let latMax = -9999;
+      let latMin = 9999;
+      let longMax = -9999;
+      let longMin = 9999;
       if (feature.properties.areaName === areaName) {
         feature.geometry.coordinates[0].map(([y, x]) => {
-          xSum += x;
-          ySum += y;
+          latMax = x > latMax ? x : latMax;
+          longMax = y > longMax ? y : longMax;
+          latMin = x < latMin ? x : latMin;
+          longMin = y < longMin ? y : longMin;
+          latSum += x;
+          longSum += y;
         });
-        const xAvg = xSum / feature.geometry.coordinates[0].length;
-        const yAvg = ySum / feature.geometry.coordinates[0].length;
-        const newCenter = [xAvg, yAvg];
-        const newZoom = 12; // hard code or now, fix later
+        const latRange = latMax - latMin;
+        const longRange = longMax - longMin;
+        const latAvg = latSum / feature.geometry.coordinates[0].length;
+        const longAvg = longSum / feature.geometry.coordinates[0].length;
+        const newCenter = [latAvg, longAvg];
+        const newZoom = calculateZoomLevel(latRange, longRange); // hard code or now, fix later
 
         dispatch(changeCenter(newCenter));
         dispatch(changeZoom(newZoom));

--- a/src/components/AnalyzeArea/ChartCard.js
+++ b/src/components/AnalyzeArea/ChartCard.js
@@ -109,5 +109,6 @@ ChartCard.propTypes = {
   leafletIds: PropTypes.array,
   zonalStatsData: PropTypes.object,
   region: PropTypes.string,
-  leafletDrawFeatureGroupRef: PropTypes.object
+  leafletDrawFeatureGroupRef: PropTypes.object,
+  map: PropTypes.object
 };

--- a/src/components/AnalyzeArea/ChartCard.js
+++ b/src/components/AnalyzeArea/ChartCard.js
@@ -41,7 +41,8 @@ export default function ChartCard(props) {
     leafletIds,
     zonalStatsData,
     region,
-    leafletDrawFeatureGroupRef
+    leafletDrawFeatureGroupRef,
+    map
   } = props;
   const summaryIndices = ['hubs', 'exposure', 'threat', 'asset', 'wildlife'];
   const analyzeAreaState = useSelector(AnalyzeAreaSelector);
@@ -65,6 +66,7 @@ export default function ChartCard(props) {
                 areaIndex={areaIndex}
                 data={zonalStatsData}
                 leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+                map={map}
               />
             </Grid>
           </div>
@@ -90,6 +92,7 @@ export default function ChartCard(props) {
                 data={zonalStatsData} // need to pick out the Summary
                 leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
                 leafletIds={leafletIds}
+                map={map}
               />
             </Grid>
           </div>

--- a/src/components/AnalyzeArea/ChartCard.js
+++ b/src/components/AnalyzeArea/ChartCard.js
@@ -57,6 +57,7 @@ export default function ChartCard(props) {
               <ChartDetails areaName={areaName}
                 areaIndex={areaIndex}
                 region={region}
+                map={map}
                 zonalStatsData={zonalStatsData} />
             </Grid>
 
@@ -82,6 +83,7 @@ export default function ChartCard(props) {
                 chartRegion={region}
                 chartIndices={summaryIndices}
                 chartType={'Summary Chart'}
+                map={map}
               />
             </Grid>
 

--- a/src/components/AnalyzeArea/ChartDetails.js
+++ b/src/components/AnalyzeArea/ChartDetails.js
@@ -64,7 +64,8 @@ export default function ChartDetails(props) {
     areaName,
     areaIndex,
     region,
-    zonalStatsData
+    zonalStatsData,
+    map
   } = props;
 
   const chartValues = useRef({
@@ -89,6 +90,7 @@ export default function ChartDetails(props) {
           zonalStatsData={zonalStatsData}
           chartType={'Summary Chart'}
           chartIndices={chartValues.current['Summary Chart']}
+          map={map}
         />
       </Box>
       <ChartDetailsActionButtons
@@ -107,6 +109,7 @@ export default function ChartDetails(props) {
           zonalStatsData={zonalStatsData}
           chartIndices={chartValues.current['Fish and Wildlife Inputs']}
           chartType={'Fish and Wildlife Inputs'}
+          map={map}
         />
       </Box>
       <ChartDetailsActionButtons
@@ -124,6 +127,7 @@ export default function ChartDetails(props) {
           zonalStatsData={zonalStatsData}
           chartIndices={chartValues.current['Threats Inputs']}
           chartType={'Threats Inputs'}
+          map={map}
         />
       </Box>
       <ChartDetailsActionButtons
@@ -140,6 +144,7 @@ export default function ChartDetails(props) {
           zonalStatsData={zonalStatsData}
           chartIndices={chartValues.current['Community Assets Inputs']}
           chartType={'Community Assets Inputs'}
+          map={map}
         />
       </Box>
       <ChartDetailsActionButtons
@@ -165,5 +170,6 @@ ChartDetails.propTypes = {
   areaName: PropTypes.string.isRequired,
   areaIndex: PropTypes.number.isRequired,
   region: PropTypes.string.isRequired,
-  zonalStatsData: PropTypes.object.isRequired
+  zonalStatsData: PropTypes.object.isRequired,
+  map: PropTypes.object
 };

--- a/src/components/AnalyzeArea/ChartSummary.js
+++ b/src/components/AnalyzeArea/ChartSummary.js
@@ -44,6 +44,8 @@ import {
   Cell
 } from 'recharts';
 
+import { useSelector } from 'react-redux';
+
 import { makeStyles } from '@mui/styles';
 import Box from '@mui/material/Box';
 import { mapConfig } from '../../configuration/config';
@@ -51,6 +53,9 @@ import { mapConfig } from '../../configuration/config';
 import ChartCustomLabels from './ChartCustomLabels';
 
 const regions = mapConfig.regions;
+
+const drawnLayersSelector = (state) => state.mapProperties.drawnLayers;
+
 
 const useStyles = makeStyles((theme) => ({
   contentBox: {
@@ -79,6 +84,7 @@ export default function ChartSummary(props) {
     chartType,
     map
   } = props;
+  const drawnLayersFromState = useSelector(drawnLayersSelector);
   const region = regions[chartRegion];
   const [chartData, setChartData] = useState([]);
 
@@ -173,70 +179,48 @@ export default function ChartSummary(props) {
   }, [zonalStatsData, handleGetZonalStatsData]);
 
   const handleMouseEnter = () => {
-    const highlight = {
+    const areaHighlightStyle = {
       color: '#dda006',
       weight: 2,
       opacity: 1
     };
-    const bufferHighlight = {
+    const bufferHighlightStyle = {
       color: '#ffc107',
       weight: 2,
       opacity: 1
     };
-    console.log('Mouse Enter');
-    // OK... guess we got the map in, now we got to find the right layer and change its color...
-    console.log('areaName', areaName);
-    for (let i = 0; i < Object.entries(map._layers).length; i++) {
-      const id = Object.entries(thisMap.current._layers)[i][0];
-      const layer = Object.entries(thisMap.current._layers)[i][1];
-      // Object.entries(thisMap.current._layers).map(([id, layer]) => {
-      if (layer.feature) {
-        // console.log('found feature ', layer.feature, '...');
-        console.log('feature: ', layer.feature);
-        console.log('feature areaName: ', layer.feature.properties.areaName);
-        const bufferLayerId = layer.feature.properties.bufferLayerId;
-        if (layer.feature.properties.areaName === areaName) {
-          console.log('feature matches! ');
-          // console.log(map._layers[id]);
-          thisMap.current._layers[id].setStyle(highlight);
-          thisMap.current._layers[bufferLayerId].setStyle(bufferHighlight);
-          break;
-          // console.log('layer.feature: ', layer.feature);
-        }
+
+    drawnLayersFromState.features.forEach((feature) => {
+      const id = feature.properties.leafletId;
+      const bufferLayerId = feature.properties.bufferLayerId;
+      if (feature.properties.areaName === areaName) {
+        thisMap.current._layers[id].setStyle(areaHighlightStyle);
+        thisMap.current._layers[bufferLayerId].setStyle(bufferHighlightStyle);
       }
-    };
+    });
   };
   const handleMouseLeave = () => {
-    console.log('Mouse Leave');
-    const highlight = {
+    const areaStyle = {
       color: '#4992f9',
       weight: 2,
       opacity: 1
     };
-    const bufferHighlight = {
+    const bufferStyle = {
       color: '#99c3ff',
       weight: 2,
       opacity: 1
     };
-    // OK... guess we got the map in, now we got to find the right layer and change its color...
-    // console.log('map.__layers: ', map._layers);
-    // console.log('areaName', areaName);
-    for (let i = 0; i < Object.entries(thisMap.current._layers).length; i++) {
-      const id = Object.entries(thisMap.current._layers)[i][0];
-      const layer = Object.entries(thisMap.current._layers)[i][1];
-    // Object.entries(thisMap.current._layers).map(([id, layer]) => {
-      if (layer.feature) {
-        // console.log('found feature ', layer.feature, '...');
-        const bufferLayerId = layer.feature.properties.bufferLayerId;
-        if (layer.feature.properties.areaName === areaName) {
-          // console.log('feature matches!');
-          thisMap.current._layers[id].setStyle(highlight);
-          thisMap.current._layers[bufferLayerId].setStyle(bufferHighlight);
-          // console.log('layer.feature: ', layer.feature);
-        }
+
+    drawnLayersFromState.features.forEach((feature) => {
+      const id = feature.properties.leafletId;
+      const bufferLayerId = feature.properties.bufferLayerId;
+      if (feature.properties.areaName === areaName) {
+        thisMap.current._layers[id].setStyle(areaStyle);
+        thisMap.current._layers[bufferLayerId].setStyle(bufferStyle);
       }
-    };
+    });
   };
+
   if (dataToPlot.current) {
     return (
       <Box className={classes.contentBox}

--- a/src/components/AnalyzeArea/ChartSummary.js
+++ b/src/components/AnalyzeArea/ChartSummary.js
@@ -195,7 +195,9 @@ export default function ChartSummary(props) {
       const bufferLayerId = feature.properties.bufferLayerId;
       if (feature.properties.areaName === areaName) {
         thisMap.current._layers[id].setStyle(areaHighlightStyle);
-        thisMap.current._layers[bufferLayerId].setStyle(bufferHighlightStyle);
+        if (bufferLayerId !== null) {
+          thisMap.current._layers[bufferLayerId].setStyle(bufferHighlightStyle);
+        }
       }
     });
   };
@@ -216,7 +218,9 @@ export default function ChartSummary(props) {
       const bufferLayerId = feature.properties.bufferLayerId;
       if (feature.properties.areaName === areaName) {
         thisMap.current._layers[id].setStyle(areaStyle);
-        thisMap.current._layers[bufferLayerId].setStyle(bufferStyle);
+        if (bufferLayerId !== null) {
+          thisMap.current._layers[bufferLayerId].setStyle(bufferStyle);
+        }
       }
     });
   };

--- a/src/components/AnalyzeArea/ChartSummary.js
+++ b/src/components/AnalyzeArea/ChartSummary.js
@@ -56,7 +56,6 @@ const regions = mapConfig.regions;
 
 const drawnLayersSelector = (state) => state.mapProperties.drawnLayers;
 
-
 const useStyles = makeStyles((theme) => ({
   contentBox: {
     display: 'flex',

--- a/src/components/AnalyzeArea/ChartSummary.js
+++ b/src/components/AnalyzeArea/ChartSummary.js
@@ -76,12 +76,14 @@ export default function ChartSummary(props) {
     zonalStatsData,
     chartRegion,
     chartIndices,
-    chartType
+    chartType,
+    map
   } = props;
   const region = regions[chartRegion];
   const [chartData, setChartData] = useState([]);
 
   const dataToPlot = useRef(true);
+  const thisMap = useRef(map);
   const chartLabel = `${chartType} ${areaName}`;
   const layerList = region.layerList;
 
@@ -170,9 +172,77 @@ export default function ChartSummary(props) {
     handleGetZonalStatsData(zonalStatsData);
   }, [zonalStatsData, handleGetZonalStatsData]);
 
+  const handleMouseEnter = () => {
+    const highlight = {
+      color: '#dda006',
+      weight: 2,
+      opacity: 1
+    };
+    const bufferHighlight = {
+      color: '#ffc107',
+      weight: 2,
+      opacity: 1
+    };
+    console.log('Mouse Enter');
+    // OK... guess we got the map in, now we got to find the right layer and change its color...
+    console.log('areaName', areaName);
+    for (let i = 0; i < Object.entries(map._layers).length; i++) {
+      const id = Object.entries(thisMap.current._layers)[i][0];
+      const layer = Object.entries(thisMap.current._layers)[i][1];
+      // Object.entries(thisMap.current._layers).map(([id, layer]) => {
+      if (layer.feature) {
+        // console.log('found feature ', layer.feature, '...');
+        console.log('feature: ', layer.feature);
+        console.log('feature areaName: ', layer.feature.properties.areaName);
+        const bufferLayerId = layer.feature.properties.bufferLayerId;
+        if (layer.feature.properties.areaName === areaName) {
+          console.log('feature matches! ');
+          // console.log(map._layers[id]);
+          thisMap.current._layers[id].setStyle(highlight);
+          thisMap.current._layers[bufferLayerId].setStyle(bufferHighlight);
+          break;
+          // console.log('layer.feature: ', layer.feature);
+        }
+      }
+    };
+  };
+  const handleMouseLeave = () => {
+    console.log('Mouse Leave');
+    const highlight = {
+      color: '#4992f9',
+      weight: 2,
+      opacity: 1
+    };
+    const bufferHighlight = {
+      color: '#99c3ff',
+      weight: 2,
+      opacity: 1
+    };
+    // OK... guess we got the map in, now we got to find the right layer and change its color...
+    // console.log('map.__layers: ', map._layers);
+    // console.log('areaName', areaName);
+    for (let i = 0; i < Object.entries(thisMap.current._layers).length; i++) {
+      const id = Object.entries(thisMap.current._layers)[i][0];
+      const layer = Object.entries(thisMap.current._layers)[i][1];
+    // Object.entries(thisMap.current._layers).map(([id, layer]) => {
+      if (layer.feature) {
+        // console.log('found feature ', layer.feature, '...');
+        const bufferLayerId = layer.feature.properties.bufferLayerId;
+        if (layer.feature.properties.areaName === areaName) {
+          // console.log('feature matches!');
+          thisMap.current._layers[id].setStyle(highlight);
+          thisMap.current._layers[bufferLayerId].setStyle(bufferHighlight);
+          // console.log('layer.feature: ', layer.feature);
+        }
+      }
+    };
+  };
   if (dataToPlot.current) {
     return (
-      <Box className={classes.contentBox} components='fieldset'>
+      <Box className={classes.contentBox}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        components='fieldset'>
         <ResponsiveContainer width="100%" height="40%">
           <BarChart data={chartData}
             width={500}
@@ -188,7 +258,7 @@ export default function ChartSummary(props) {
             </text>
 
             <XAxis dataKey="tickLabel" tick={<ChartCustomLabels />} style={{ fontSize: '8px' }} interval={0} height={80} />
-            <YAxis domain={[0, 1]} tickFormatter={formatYAxis} style={{ fontSize: '10px' }} interval={0}/>
+            <YAxis domain={[0, 1]} tickFormatter={formatYAxis} style={{ fontSize: '10px' }} interval={0} />
 
             <Tooltip content={<CustomTooltip />} />
             <Bar dataKey='chartValue' >
@@ -211,5 +281,6 @@ ChartSummary.propTypes = {
   zonalStatsData: PropTypes.object,
   chartRegion: PropTypes.string.isRequired,
   chartIndices: PropTypes.array.isRequired,
-  chartType: PropTypes.string
+  chartType: PropTypes.string,
+  map: PropTypes.object
 };

--- a/src/components/AnalyzeArea/ChartsHolder.js
+++ b/src/components/AnalyzeArea/ChartsHolder.js
@@ -73,7 +73,7 @@ const drawnLayerSelector = (state) => state.mapProperties.drawnLayers;
 const selectedRegionSelector = (state) => state.selectedRegion.value;
 
 export default function ChartsHolder(props) {
-  const { leafletDrawFeatureGroupRef } = props;
+  const { leafletDrawFeatureGroupRef, map } = props;
   const drawnLayerAreas = useSelector(drawnLayerSelector);
   const selectedRegion = useSelector(selectedRegionSelector);
   // console.log('drawn layer');
@@ -214,6 +214,7 @@ export default function ChartsHolder(props) {
                   region={thisRegion}
                   zonalStatsData={zonalStatsData}
                   leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+                  map={map}
                 />
               );
             })}

--- a/src/components/AnalyzeArea/ChartsHolder.js
+++ b/src/components/AnalyzeArea/ChartsHolder.js
@@ -233,5 +233,6 @@ export default function ChartsHolder(props) {
 }
 
 ChartsHolder.propTypes = {
-  leafletDrawFeatureGroupRef: PropTypes.object
+  leafletDrawFeatureGroupRef: PropTypes.object,
+  map: PropTypes.object
 };

--- a/src/components/Map/MapHolder.js
+++ b/src/components/Map/MapHolder.js
@@ -104,6 +104,7 @@ export default function MapHolder(props) {
           boxHeight={'calc(100% - 258px)'}
           boxMarginTop={'8px'}
           leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+          map={map}
         />
       </Grid>
 


### PR DESCRIPTION
This PR contains code to highlight the area shapes on the map when mousing over the relevant charts.  It DOES pull in the updates from `zoom-areas` as well, so that should be merged first. Other changes include passing down `leafletDrawFeatureGroupRef` and map through props in order to be accessed from the `chartSummary`.  `leafletDrawFeatureGroup `is used for the look up of it, and `map._layers` is used to update the style of the area.