### PR TITLE
Add geocoder search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "chart.js": "^3.9.1",
         "debounce": "^1.2.1",
         "esri-leaflet": "^3.0.8",
+        "esri-leaflet-geocoder": "^3.1.4",
         "esri-leaflet-vector": "^4.0.0",
         "gh-pages": "^3.2.3",
         "jest-environment-jsdom": "^28.1.0",
@@ -9693,6 +9694,15 @@
         "tiny-binary-search": "^1.0.3"
       },
       "peerDependencies": {
+        "leaflet": "^1.0.0"
+      }
+    },
+    "node_modules/esri-leaflet-geocoder": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/esri-leaflet-geocoder/-/esri-leaflet-geocoder-3.1.4.tgz",
+      "integrity": "sha512-VMqWgbB7/3X8GuIaUemn/NGlLr3BB51ZpBWBfj/Q71HDXBKIPnGExUuXU9wqblYlj1j3w8uhwVKSGEHPpX+QiA==",
+      "dependencies": {
+        "esri-leaflet": "^3.0.2",
         "leaflet": "^1.0.0"
       }
     },
@@ -25209,6 +25219,15 @@
       "requires": {
         "@terraformer/arcgis": "^2.1.0",
         "tiny-binary-search": "^1.0.3"
+      }
+    },
+    "esri-leaflet-geocoder": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/esri-leaflet-geocoder/-/esri-leaflet-geocoder-3.1.4.tgz",
+      "integrity": "sha512-VMqWgbB7/3X8GuIaUemn/NGlLr3BB51ZpBWBfj/Q71HDXBKIPnGExUuXU9wqblYlj1j3w8uhwVKSGEHPpX+QiA==",
+      "requires": {
+        "esri-leaflet": "^3.0.2",
+        "leaflet": "^1.0.0"
       }
     },
     "esri-leaflet-vector": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "chart.js": "^3.9.1",
     "debounce": "^1.2.1",
     "esri-leaflet": "^3.0.8",
+    "esri-leaflet-geocoder": "^3.1.4",
     "esri-leaflet-vector": "^4.0.0",
     "gh-pages": "^3.2.3",
     "jest-environment-jsdom": "^28.1.0",

--- a/src/components/Map/DrawnLayers.js
+++ b/src/components/Map/DrawnLayers.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FeatureGroup } from 'react-leaflet';
+import PropTypes from 'prop-types';
+import LeafletDrawTools from './LeafletDrawTools';
+
+export default function DrawnLayers(props) {
+  const {
+    map,
+    leafletFeatureGroupRef,
+    bufferCheckbox,
+    setDrawAreaDisabled,
+    setTooLargeLayerOpen
+  } = props;
+  return (
+    <FeatureGroup ref={leafletFeatureGroupRef}>
+      <LeafletDrawTools
+        map={map}
+        leafletDrawFeatureGroupRef={leafletFeatureGroupRef}
+        bufferCheckbox={bufferCheckbox}
+        setDrawAreaDisabled={setDrawAreaDisabled}
+        setTooLargeLayerOpen={setTooLargeLayerOpen}
+      />
+    </FeatureGroup>
+  );
+}
+
+DrawnLayers.propTypes = {
+  map: PropTypes.object,
+  bufferCheckbox: PropTypes.bool,
+  leafletFeatureGroupRef: PropTypes.object,
+  setDrawAreaDisabled: PropTypes.func,
+  setTooLargeLayerOpen: PropTypes.func
+};

--- a/src/components/Map/LeafletDrawTools.js
+++ b/src/components/Map/LeafletDrawTools.js
@@ -214,7 +214,6 @@ export default function LeafletDrawTools(props) {
     if (!searchPlacesGeoJSON) {
       return;
     }
-    console.log(searchPlacesGeoJSON);
     const layer = L.geoJSON(searchPlacesGeoJSON);
     leafletDrawFeatureGroupRef.current.addLayer(layer);
     const areaName = `Area ${areaNumber}`;
@@ -234,10 +233,10 @@ export default function LeafletDrawTools(props) {
         setDrawAreaDisabled(false);
       });
     });
-    console.log(layer);
 
     dispatch(addSearchPlacesGeoJSON(null));
-  }, [searchPlacesGeoJSON, dispatch]);
+  // eslint-disable-next-line max-len
+  }, [searchPlacesGeoJSON, dispatch, leafletDrawFeatureGroupRef, areaNumber, createBufferLayer, enrichGeoJsonWithProperties, classes.leafletTooltips, selectedRegion, setDrawAreaDisabled]);
 
   function onCreated(e) {
     // Toggle sketch area off since new area was just created

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -40,7 +40,6 @@ import React, {
 import { useSelector, useDispatch } from 'react-redux';
 import {
   useMapEvents,
-  FeatureGroup,
   LayersControl
   // GeoJSON,
   // Polygon
@@ -52,7 +51,6 @@ import { Button } from '@mui/material';
 import Control from 'react-leaflet-custom-control';
 import PropTypes from 'prop-types';
 
-import LeafletDrawTools from './LeafletDrawTools';
 import ActiveTileLayers from './ActiveTileLayers';
 import SearchPlaces from './SearchPlaces';
 import BasemapLayer from './BasemapLayer';

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -68,6 +68,7 @@ import ActionButtons from './ActionButtons';
 import { createShareURL } from './ShareMap';
 import ModelErrors from '../All/ModelErrors';
 import ModalShare from '../All/ModalShare';
+import DrawnLayers from './DrawnLayers';
 
 // import Boxforlayout from './BoxForLayouts';
 
@@ -105,7 +106,7 @@ export default function MapCard(props) {
     map,
     setMap,
     bufferCheckbox,
-    leafletDrawFeatureGroupRef,
+    leafletFeatureGroupRef,
     setDrawAreaDisabled,
     tooLargeLayerOpen,
     setTooLargeLayerOpen
@@ -172,7 +173,7 @@ export default function MapCard(props) {
         );
       },
       zoomend: () => {
-        const featureGroup = leafletDrawFeatureGroupRef.current;
+        const featureGroup = leafletFeatureGroupRef.current;
         featureGroup.eachLayer((layer) => {
           if (map.getZoom() < 10) {
             layer.closeTooltip();
@@ -244,15 +245,13 @@ export default function MapCard(props) {
         </Control>
         <LayersControl position="topright">
           <LayersControl.Overlay checked name="leaflet-draw">
-            <FeatureGroup ref={leafletDrawFeatureGroupRef}>
-              <LeafletDrawTools
-                map={map}
-                leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
-                bufferCheckbox={bufferCheckbox}
-                setDrawAreaDisabled={setDrawAreaDisabled}
-                setTooLargeLayerOpen={setTooLargeLayerOpen}
-              />
-            </FeatureGroup>
+            <DrawnLayers
+              map={map}
+              leafletFeatureGroupRef={leafletFeatureGroupRef}
+              bufferCheckbox={bufferCheckbox}
+              setDrawAreaDisabled={setDrawAreaDisabled}
+              setTooLargeLayerOpen={setTooLargeLayerOpen}
+            />
           </LayersControl.Overlay>
         </LayersControl>
         <ModalShare
@@ -276,7 +275,7 @@ export default function MapCard(props) {
         <ActiveTileLayers />
         <BasemapLayer map={map} />
         <MapEventsComponent />
-        <SearchPlaces map = {map} leafletFeatureGroupRef={leafletDrawFeatureGroupRef}/>
+        <SearchPlaces map = {map} leafletFeatureGroupRef={leafletFeatureGroupRef}/>
         <ShowIdentifyPopup
           selectedRegion = {selectedRegion}
           map = {map}
@@ -292,7 +291,7 @@ MapCard.propTypes = {
   bufferCheckbox: PropTypes.bool,
   map: PropTypes.object,
   setMap: PropTypes.func,
-  leafletDrawFeatureGroupRef: PropTypes.object,
+  leafletFeatureGroupRef: PropTypes.object,
   setDrawAreaDisabled: PropTypes.func,
   tooLargeLayerOpen: PropTypes.bool,
   setTooLargeLayerOpen: PropTypes.func

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -54,6 +54,7 @@ import PropTypes from 'prop-types';
 
 import LeafletDrawTools from './LeafletDrawTools';
 import ActiveTileLayers from './ActiveTileLayers';
+import SearchPlaces from './SearchPlaces';
 import BasemapLayer from './BasemapLayer';
 import { changeRegion, regionUserInitiated } from '../../reducers/regionSelectSlice';
 import {
@@ -268,6 +269,7 @@ export default function MapCard(props) {
         <ActiveTileLayers />
         <BasemapLayer map={map} />
         <MapEventsComponent />
+        <SearchPlaces map = {map}/>
         <ShowIdentifyPopup
           selectedRegion = {selectedRegion}
           map = {map}

--- a/src/components/Map/MapCard.js
+++ b/src/components/Map/MapCard.js
@@ -276,7 +276,7 @@ export default function MapCard(props) {
         <ActiveTileLayers />
         <BasemapLayer map={map} />
         <MapEventsComponent />
-        <SearchPlaces map = {map}/>
+        <SearchPlaces map = {map} leafletFeatureGroupRef={leafletDrawFeatureGroupRef}/>
         <ShowIdentifyPopup
           selectedRegion = {selectedRegion}
           map = {map}

--- a/src/components/Map/MapHolder.js
+++ b/src/components/Map/MapHolder.js
@@ -72,7 +72,7 @@ export default function MapHolder(props) {
   const [bufferCheckbox, setBufferCheckbox] = useState(true);
   const [drawAreaDisabled, setDrawAreaDisabled] = useState(false);
   const [tooLargeLayerOpen, setTooLargeLayerOpen] = useState(false);
-  const leafletDrawFeatureGroupRef = useRef();
+  const leafletFeatureGroupRef = useRef();
 
   const listVisibleSelector = (state) => state.mapLayerList.visible;
   const layerListVisible = useSelector(listVisibleSelector);
@@ -103,7 +103,7 @@ export default function MapHolder(props) {
         <AnalyzeAreaHolder
           boxHeight={'calc(100% - 258px)'}
           boxMarginTop={'8px'}
-          leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+          leafletFeatureGroupRef={leafletFeatureGroupRef}
           map={map}
         />
       </Grid>
@@ -121,7 +121,7 @@ export default function MapHolder(props) {
           <MapCard
             map={map}
             setMap={setMap}
-            leafletDrawFeatureGroupRef={leafletDrawFeatureGroupRef}
+            leafletFeatureGroupRef={leafletFeatureGroupRef}
             bufferCheckbox={bufferCheckbox}
             setDrawAreaDisabled={setDrawAreaDisabled}
             tooLargeLayerOpen={tooLargeLayerOpen}

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -20,3 +20,36 @@ State needed
 Props
   Not sure yet
 */
+import React, { useEffect } from 'react';
+import L from 'leaflet';
+import { geosearch } from 'esri-leaflet-geocoder';
+import * as ELG from 'esri-leaflet-geocoder';
+
+export default function SearchPlaces(props) {
+  const { map } = props;
+  const apiKey = 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By';
+  const handleOnSearchResuts = (data) => {
+    console.log('Search results', data);
+  };
+  useEffect(() => {
+    if (!map) { return; }
+    const searchControl = geosearch({
+      providers: [
+        ELG.arcgisOnlineProvider({
+          // API Key to be passed to the ArcGIS Online Geocoding Service
+          apikey: apiKey
+        })
+      ]
+    });
+    searchControl.addTo(map);
+
+    searchControl.on('results', handleOnSearchResuts);
+    return () => {
+      searchControl.off('results', handleOnSearchResuts);
+    }
+  }, [map]);
+
+  return (
+    <div />
+  );
+}

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -33,7 +33,8 @@ import LeafletDrawTools from './LeafletDrawTools';
 import {
   addNewFeatureToDrawnLayers,
   uploadedShapeFileGeoJSON,
-  addNewFeatureToZonalStatsAreas
+  addNewFeatureToZonalStatsAreas,
+  addSearchPlacesGeoJSON
 } from '../../reducers/mapPropertiesSlice';
 
 export default function SearchPlaces(props) {
@@ -64,14 +65,9 @@ export default function SearchPlaces(props) {
 
   const handleGetAreaStatistics = useCallback(() => {
     const thisArea = L.circle(identifyDataRef.current, { radius: 1000 });
-    const fakeLayer = { layer: thisArea };
     const asGJSON = thisArea.toGeoJSON();
-    console.log(asGJSON);
-    thisArea.on('add', () => LeafletDrawTools.onCreated(fakeLayer));
-    console.log('the circle printed: ', thisArea);
-    // PULL IN ONCREATED here, and dummy out an event containing a "layer"
-    leafletFeatureGroupRef.current.addLayer(thisArea);
-  }, [leafletFeatureGroupRef]);
+    dispatch(addSearchPlacesGeoJSON(asGJSON));
+  }, [dispatch]);
 
   const handleOnSearchResuts = useCallback((data) => {
     console.log('Search results', data);

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -20,36 +20,81 @@ State needed
 Props
   Not sure yet
 */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import { Popup } from 'react-leaflet';
 import L from 'leaflet';
+import { Button, IconButton } from '@mui/material/';
+
 import { geosearch } from 'esri-leaflet-geocoder';
 import * as ELG from 'esri-leaflet-geocoder';
+import ShowIdentifyPopup from './Identify';
+import { makeStyles } from '@mui/styles';
+import InfoIcon from '@mui/icons-material/Info';
 
 export default function SearchPlaces(props) {
   const { map } = props;
+
+  let identifyData = null;
   const apiKey = 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By';
+  const [popupContent, setPopupContent] = useState(null);
+  const searchControlRef = useRef(null);
+
+
   const handleOnSearchResuts = (data) => {
     console.log('Search results', data);
+    identifyData = data.latlng;
+    console.log(identifyData);
+
+    setPopupContent(
+      <Popup position={identifyData} onClose={() => setPopupContent(null)}>
+        <div>
+          <h2>{data.results[0].text}</h2>
+          <p><IconButton
+            variant="contained"
+            aria-label="Close"
+            color="CRESTSecondary"
+            onClick={(() => console.log('clicked identify!'))}>
+            <InfoIcon />
+          </IconButton>
+            <Button
+              variant="contained"
+              color="CRESTPrimary"
+              onClick={(() => console.log('clicked explore!'))}
+            >Explore</Button></p>
+        </div>
+      </Popup>
+    );
   };
   useEffect(() => {
     if (!map) { return; }
-    const searchControl = geosearch({
-      providers: [
-        ELG.arcgisOnlineProvider({
-          // API Key to be passed to the ArcGIS Online Geocoding Service
-          apikey: apiKey
-        })
-      ]
-    });
-    searchControl.addTo(map);
 
-    searchControl.on('results', handleOnSearchResuts);
-    return () => {
-      searchControl.off('results', handleOnSearchResuts);
+    if (!searchControlRef.current) {
+      const searchControl = geosearch({
+        providers: [
+          ELG.arcgisOnlineProvider({
+            // API Key to be passed to the ArcGIS Online Geocoding Service
+            apikey: apiKey
+          })
+        ]
+      });
+      searchControl.addTo(map);
+      searchControlRef.current = searchControl;
+
+
+      searchControlRef.current.on('results', handleOnSearchResuts);
+      return () => {
+        searchControlRef.current.off('results', handleOnSearchResuts);
+      }
     }
-  }, [map]);
+  }, [handleOnSearchResuts, map]);
 
   return (
-    <div />
+    <>
+      {popupContent}
+    </>
   );
+  // return (
+  //   isSearched ? <div /> : <ShowIdentifyPopup map={map} selectedRegion={identifyData} />
+
+  // );
 }

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -62,29 +62,6 @@ export default function SearchPlaces(props) {
 
   const searchControlRef = useRef(null);
 
-  const circleToPolygon = (circle) => {
-    const numSegments = 32; // Default number of segments
-
-    const center = circle.getLatLng();
-    const radius = circle.getRadius();
-
-    console.log('center: ', center, ' radius: ', radius);
-    const points = [];
-    const angle = (Math.PI * 2) / numSegments;
-
-    for (let i = 0; i < numSegments; i++) {
-      const theta = angle * i;
-      const x = center.lng + radius * Math.cos(theta);
-      const y = center.lat + radius * Math.sin(theta);
-      points.push([y, x]);
-    }
-
-    const polygon = L.polygon(points);
-    console.log('polygon: ', polygon);
-    console.log('points: ', points);
-    return polygon;
-  }
-
   const handleGetAreaStatistics = useCallback(() => {
     const circle = L.circle(identifyDataRef.current, { radius: 1000 });
     const centerLatLng = circle.getLatLng();

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -20,42 +20,25 @@ State needed
 Props
   Not sure yet
 */
-import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, {
+  useEffect, useState, useRef, useCallback
+} from 'react';
+import { useDispatch } from 'react-redux';
 import { Popup } from 'react-leaflet';
 import * as L from 'leaflet';
 import { Button } from '@mui/material/';
 import AddchartIcon from '@mui/icons-material/Addchart';
 import { geosearch } from 'esri-leaflet-geocoder';
+import PropTypes from 'prop-types';
 import * as ELG from 'esri-leaflet-geocoder';
-import LeafletDrawTools from './LeafletDrawTools';
 import * as turf from '@turf/turf';
 
-import {
-  addNewFeatureToDrawnLayers,
-  uploadedShapeFileGeoJSON,
-  addNewFeatureToZonalStatsAreas,
-  addSearchPlacesGeoJSON
-} from '../../reducers/mapPropertiesSlice';
+import { addSearchPlacesGeoJSON } from '../../reducers/mapPropertiesSlice';
 
 export default function SearchPlaces(props) {
-  const { map, leafletFeatureGroupRef } = props;
+  const { map } = props;
   const dispatch = useDispatch();
   const apiKey = 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By';
-  const GeoSearchOptions = {
-    providers: [
-      ELG.arcgisOnlineProvider({
-        // API Key to be passed to the ArcGIS Online Geocoding Service
-        apikey: apiKey
-      })
-    ],
-    useMapBounds: false,
-    expanded: false,
-    placeholder: 'Search for places or addresses',
-    collapseAfterResult: false,
-    allowMultipleResults: false,
-    attribution: 'Powered by ESRI'
-  };
 
   const identifyDataRef = useRef(null);
   const [popupContent, setPopupContent] = useState(null);
@@ -72,16 +55,12 @@ export default function SearchPlaces(props) {
     const turfCircle = turf.circle(center, radius, options);
     const newTurfCircle = new L.GeoJSON(turfCircle);
     const asGJSON = newTurfCircle.toGeoJSON();
-    // const thisArea = circleToPolygon(thisCircle);
-    // thisArea.addTo(map);
-    // console.log('this area: ', thisArea);
-    // const asGJSON = thisArea.toGeoJSON();
     dispatch(addSearchPlacesGeoJSON(asGJSON));
   }, [dispatch]);
 
   const handleOnSearchResuts = useCallback((data) => {
     identifyDataRef.current = data.latlng;
- 
+
     setPopupContent(
       <Popup position={identifyDataRef.current} onClose={() => setPopupContent(null)}>
         <div>
@@ -94,11 +73,26 @@ export default function SearchPlaces(props) {
         </div>
       </Popup>
     );
-  }, [handleGetAreaStatistics, map]);
+  }, [handleGetAreaStatistics]);
+
   useEffect(() => {
     if (!map) { return; }
 
     if (!searchControlRef.current) {
+      const GeoSearchOptions = {
+        providers: [
+          ELG.arcgisOnlineProvider({
+            // API Key to be passed to the ArcGIS Online Geocoding Service
+            apikey: apiKey
+          })
+        ],
+        useMapBounds: false,
+        expanded: false,
+        placeholder: 'Search for places or addresses',
+        collapseAfterResult: false,
+        allowMultipleResults: false,
+        attribution: 'Powered by ESRI'
+      };
       const searchControl = geosearch(GeoSearchOptions);
       searchControl.addTo(map);
       searchControlRef.current = searchControl;
@@ -108,15 +102,15 @@ export default function SearchPlaces(props) {
       // searchControlRef.current.off('results', handleOnSearchResuts);
       // };
     }
-  }, [GeoSearchOptions, handleOnSearchResuts, map]);
+  }, [handleOnSearchResuts, map]);
 
   return (
     <>
       {popupContent}
     </>
   );
-  // return (
-  //   isSearched ? <div /> : <ShowIdentifyPopup map={map} selectedRegion={identifyData} />
-
-  // );
 }
+
+SearchPlaces.propTypes = {
+  map: PropTypes.object
+};

--- a/src/components/Map/SearchPlaces.js
+++ b/src/components/Map/SearchPlaces.js
@@ -20,73 +20,129 @@ State needed
 Props
   Not sure yet
 */
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Popup } from 'react-leaflet';
 import L from 'leaflet';
-import { Button, IconButton } from '@mui/material/';
-
+import { Button } from '@mui/material/';
+import AddchartIcon from '@mui/icons-material/Addchart';
 import { geosearch } from 'esri-leaflet-geocoder';
 import * as ELG from 'esri-leaflet-geocoder';
-import ShowIdentifyPopup from './Identify';
 import { makeStyles } from '@mui/styles';
 import InfoIcon from '@mui/icons-material/Info';
+import ShowIdentifyPopup from './Identify';
+import {
+  addNewFeatureToDrawnLayers,
+  uploadedShapeFileGeoJSON,
+  addNewFeatureToZonalStatsAreas
+} from '../../reducers/mapPropertiesSlice';
 
 export default function SearchPlaces(props) {
-  const { map } = props;
+  const { map, leafletDrawFeatureGroupRef } = props;
+  const dispatch = useDispatch();
+  const apiKey = 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By';
+  const GeoSearchOptions = {
+    providers: [
+      ELG.arcgisOnlineProvider({
+        // API Key to be passed to the ArcGIS Online Geocoding Service
+        apikey: apiKey
+      })
+    ],
+    useMapBounds: false,
+    expanded: false,
+    placeholder: 'Search for places or addresses',
+    collapseAfterResult: false,
+    allowMultipleResults: false,
+    attribution: 'Powered by ESRI'
+  };
 
   let identifyData = null;
-  const apiKey = 'AAPKa0a45bdbd847441badbdcf07a97939bd0Y1Vpjt3MU7qyu7R9QThGqpucpKmbVXGEdmQo1hqhdjLDKA2zrwty2aeDjT-7-By';
   const [popupContent, setPopupContent] = useState(null);
+
   const searchControlRef = useRef(null);
+  // const searchLocation = useRef(null);
 
+  function circleToFeature(circle) {
+    const center = circle.getLatLng();
+    const radius = circle.getRadius();
+    const feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [center.lng, center.lat]
+      },
+      properties: {
+        radius,
+        areaName: 'TESTAREA'
+      }
+    };
+    return feature;
+  }
 
-  const handleOnSearchResuts = (data) => {
+  const handleOnSearchResuts = useCallback((data) => {
     console.log('Search results', data);
     identifyData = data.latlng;
     console.log(identifyData);
+
+    const handleGetAreaStatistics = (data) => {
+      const thisArea = L.circle(identifyData, { radius: 1000 });
+      thisArea.addTo(map);
+      const newFeature = circleToFeature(thisArea);
+      // newLayer.addTo(map);
+
+      let layer = L.geoJSON(newFeature);
+      const layerId = L.stamp(layer);
+      newFeature.properties.leafletId = layerId;
+      const leafletIdsList = [layerId];
+      leafletDrawFeatureGroupRef.current.addLayer(layer);
+      // layer.bindTooltip('TESTAREATT', { direction: 'center', permanent: true });
+      if (newFeature.properties.buffer) {
+        // layer = buffer(layer.toGeoJSON(), bufferSize, { units: bufferUnits });
+        // layer = L.geoJSON(layer, { style: bufferStyle });
+        // const bufferLayerId = L.stamp(layer);
+        // newFeature.properties.bufferLayerId = bufferLayerId;
+        // leafletIdsList.push(bufferLayerId);
+        leafletDrawFeatureGroupRef.current.addLayer(layer);
+      }
+      newFeature.properties.leafletIds = leafletIdsList;
+      // dispatch(addNewFeatureToDrawnLayers(newFeature));
+      // dispatch(addNewFeatureToZonalStatsAreas(newFeature));
+      dispatch(uploadedShapeFileGeoJSON(newFeature));
+      console.log(newFeature);
+      searchControlRef.current.clear();
+
+      // return(
+      //   <Circle center={identifyData} radius={1000} />
+      // )
+    };
 
     setPopupContent(
       <Popup position={identifyData} onClose={() => setPopupContent(null)}>
         <div>
           <h2>{data.results[0].text}</h2>
-          <p><IconButton
+          <p><Button
             variant="contained"
-            aria-label="Close"
-            color="CRESTSecondary"
-            onClick={(() => console.log('clicked identify!'))}>
-            <InfoIcon />
-          </IconButton>
-            <Button
-              variant="contained"
-              color="CRESTPrimary"
-              onClick={(() => console.log('clicked explore!'))}
-            >Explore</Button></p>
+            color="CRESTPrimary"
+            onClick={handleGetAreaStatistics}
+          ><AddchartIcon /> Get Statistics for this location</Button></p>
         </div>
       </Popup>
     );
-  };
+  }, []);
   useEffect(() => {
     if (!map) { return; }
 
     if (!searchControlRef.current) {
-      const searchControl = geosearch({
-        providers: [
-          ELG.arcgisOnlineProvider({
-            // API Key to be passed to the ArcGIS Online Geocoding Service
-            apikey: apiKey
-          })
-        ]
-      });
+      const searchControl = geosearch(GeoSearchOptions);
       searchControl.addTo(map);
       searchControlRef.current = searchControl;
 
-
       searchControlRef.current.on('results', handleOnSearchResuts);
-      return () => {
-        searchControlRef.current.off('results', handleOnSearchResuts);
-      }
+      // return () => {
+        // searchControlRef.current.off('results', handleOnSearchResuts);
+      // };
     }
-  }, [handleOnSearchResuts, map]);
+  }, [GeoSearchOptions, handleOnSearchResuts, map]);
 
   return (
     <>

--- a/src/reducers/mapPropertiesSlice.js
+++ b/src/reducers/mapPropertiesSlice.js
@@ -75,6 +75,11 @@ export const mapPropertiesSlice = createSlice({
     },
     uploadedShapeFileGeoJSON: (state, action) => {
       state.uploadedShapeFileGeoJSON = action.payload;
+    },
+    addSearchPlacesGeoJSON: (state, action) => {
+      console.log('reached dispatch!');
+      console.log(action.payload);
+      state.searchPlacesFileGeoJSON = action.payload;
     }
   }
 });
@@ -85,7 +90,7 @@ export const {
   changeIdentifyResults, changeIdentifyIsLoaded, changeBasemap,
   toggleSketchArea, addNewFeatureToZonalStatsAreas, removeAllFeaturesFromZonalStatsAreas,
   removeFeatureFromZonalStatsAreas, addNewFeatureToDrawnLayers, removeFeatureFromDrawnLayers,
-  removeAllFeaturesFromDrawnLayers, uploadedShapeFileGeoJSON
+  removeAllFeaturesFromDrawnLayers, uploadedShapeFileGeoJSON, addSearchPlacesGeoJSON
 } = mapPropertiesSlice.actions;
 
 export default mapPropertiesSlice.reducer;

--- a/src/reducers/mapPropertiesSlice.js
+++ b/src/reducers/mapPropertiesSlice.js
@@ -77,8 +77,6 @@ export const mapPropertiesSlice = createSlice({
       state.uploadedShapeFileGeoJSON = action.payload;
     },
     addSearchPlacesGeoJSON: (state, action) => {
-      console.log('reached dispatch!');
-      console.log(action.payload);
       state.searchPlacesFileGeoJSON = action.payload;
     }
   }


### PR DESCRIPTION
This pull requests adds a search bar for place/location search.  It uses ESRI geocoder to do the lookups and much of the logic for drawing the shapes and pulling their stats exists in leafletDrawTools.js.  There's definitely going to be a need to make a couple of fixes surrounding the buffer which are noticeable in these changes - namely the highlight feature needs to be updated to accommodate non-buffered regions.  That seems like it belongs on a different PR though, so not doing that here right now for. simplicity.