### PR TITLE
updates to still generate charts with 0 values when no data is provided

### DIFF
--- a/src/components/AnalyzeArea/ChartActionButtons.js
+++ b/src/components/AnalyzeArea/ChartActionButtons.js
@@ -129,7 +129,7 @@ export default function ChartActionButtons(props) {
     Object.entries(data).map(([index, value]) => {
       const thisRow = [];
       thisRow.push(getLabel(index)); // need to get label here
-      thisRow.push(Number.isNaN(Number(value)) ? 'No Data' : value.toFixed(3)); // need to get value here
+      thisRow.push(Number.isNaN(Number(value)) ? '0.0' : value.toFixed(3)); // need to get value here
       thisRow.push(getRange(index)); // need to get range here
       dataRows.push(thisRow);
       return thisRow;

--- a/src/components/AnalyzeArea/ChartDetailsActionButtons.js
+++ b/src/components/AnalyzeArea/ChartDetailsActionButtons.js
@@ -81,7 +81,7 @@ export default function ChartDetailsActionButtons(props) {
       const thisRow = [];
       if (chartIndices.includes(index)) {
         thisRow.push(getLabel(index)); // need to get label here
-        thisRow.push(Number.isNaN(Number(value)) ? 'No Data' : value.toFixed(3)); // need to get value here
+        thisRow.push(Number.isNaN(Number(value)) ? '0.0' : value.toFixed(3)); // need to get value here
         thisRow.push(getRange(index)); // need to get range here
         dataRows.push(thisRow);
       }

--- a/src/components/AnalyzeArea/ChartSummary.js
+++ b/src/components/AnalyzeArea/ChartSummary.js
@@ -166,7 +166,7 @@ export default function ChartSummary(props) {
     // Currently this is going to pull all data across all regions... need to simplify
     // An error occurs when trying to cross-reference the wrong data/region combo
     Object.entries(data).forEach(([key, value]) => {
-      if (chartIndices.includes(key) && !value.isNaN && value > 0) {
+      if (chartIndices.includes(key)) {
         const layerData = getData(key, value);
         const barColor = layerData[0];
         const chartValue = layerData[1];

--- a/src/components/AnalyzeArea/ChartsHolder.js
+++ b/src/components/AnalyzeArea/ChartsHolder.js
@@ -157,7 +157,7 @@ export default function ChartsHolder(props) {
         if (area.region === selectedRegion) {
           thisRow.push(area.areaName);
           thisRow.push(getLabel(area, index)); // need to get label here
-          thisRow.push(Number.isNaN(Number(value)) ? 'No Data' : value.toFixed(3)); // need to get value here
+          thisRow.push(Number.isNaN(Number(value)) ? '0.0' : value.toFixed(3)); // need to get value here
           thisRow.push(getRange(area, index)); // need to get range here
           dataRows.push(thisRow);
         }

--- a/src/components/AnalyzeArea/TableData.js
+++ b/src/components/AnalyzeArea/TableData.js
@@ -108,7 +108,7 @@ export default function TableData(props) {
                       <StyledTableRow key={`${row.areaName}-${row.name}`}>
                         <TableCell align="left">{row.areaName}</TableCell>
                         <TableCell align="left">{getLabel(row, ind)}</TableCell>
-                        <TableCell align="left">{Number.isNaN(Number(val)) ? 'No Data' : val.toFixed(3)}</TableCell>
+                        <TableCell align="left">{Number.isNaN(Number(val)) ? '0.0' : val.toFixed(3)}</TableCell>
                         <TableCell align="left">{getRange(row, ind)}</TableCell>
                       </StyledTableRow>
                     </React.Fragment>)));


### PR DESCRIPTION
Previously when no data was available, it was putting a H3 that said NO DATA in place of the chart.  The Chart is now rendered with 0'd out values.