### PR TITLE
Fixed a few stlye options and adjustments for screen size

### DIFF
--- a/src/CRESTTheme/CRESTCustomTheme.js
+++ b/src/CRESTTheme/CRESTCustomTheme.js
@@ -175,6 +175,16 @@ const CustomTheme = createTheme({
         }
       ]
     }
+  },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+      xxl: 2000
+    }
   }
 });
 

--- a/src/components/About/AboutTabs.js
+++ b/src/components/About/AboutTabs.js
@@ -45,9 +45,7 @@ const StyledAboutTab = styled(Tab)(({ theme }) => ({
   },
   '&.Mui-selected': {
     backgroundColor: theme.palette.CRESTGridBackground.dark,
-    borderColor: theme.palette.CRESTBorderColor.main,
-    border: 1,
-    borderStyle: 'solid',
+    border: `1px solid ${theme.palette.CRESTBorderColor.main}`,
     '&:hover': {
       backgroundColor: theme.palette.CRESTDarkAlt.main
     },

--- a/src/components/Home/RegionCard.js
+++ b/src/components/Home/RegionCard.js
@@ -39,7 +39,10 @@ const StyledBox = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   display: 'flex',
   width: '100%',
-  height: '150px'
+  height: '150px',
+  [theme.breakpoints.up('xxl')]: {
+    height: '250px'
+  }
 }));
 
 // just a place holder needs props passed in and image etc

--- a/src/components/Home/Regions.js
+++ b/src/components/Home/Regions.js
@@ -47,7 +47,7 @@ export default function Regions() {
     <Grid container spacing={3} justifyContent="center" alignItems="center" px={0.25} py={0.75}>
 
       { Object.keys(regions).map((region) => (
-        <Grid xs={12} sm={12} md={6} lg={3} key={regions[region].label}>
+        <Grid xs={12} sm={12} md={6} lg={3} xxl={2} key={regions[region].label}>
           <RegionCard
             regionName={regions[region].label}
             regionImage={regions[region].image}

--- a/src/components/Map/MapHolder.js
+++ b/src/components/Map/MapHolder.js
@@ -40,6 +40,9 @@ const ContentHolderGrid = styled(Grid)(({ theme }) => ({
   height: 'calc(100% - 123px)',
   [theme.breakpoints.down('lg')]: {
     height: 'calc(100% - 56px)'
+  },
+  [theme.breakpoints.down('md')]: {
+    height: 'calc(60% - 56px)'
   }
 }));
 


### PR DESCRIPTION
- Fixed my lint errors
- Added a new `xxl` break-point for very large screens, which adjusted the home page, but we may need more. For any screen widths over 2000, use `XXL`.   The new BreakPoint is `xxl: 2000`
- Update for map height on smaller screens so we can fit map and map actions together. The map was 100% height on smaller screens, and it was unclear whether you could change map layers, see graphs, etc.