### PR TITLE
fix for card size wrapping with longer region titles

### DIFF
--- a/src/components/Home/RegionCard.js
+++ b/src/components/Home/RegionCard.js
@@ -58,8 +58,15 @@ export default function RegionCard(props) {
   };
 
   return (
-    <Box>
-      <StyledPaper variant="outlined" square={false} >
+    <Box sx={{ height: '100%' }}>
+      <StyledPaper
+        variant="outlined"
+        square={false}
+        sx={{
+          display: 'flex',
+          height: '100%',
+          flexDirection: 'column'
+        }}>
         <Typography variant="h6" component="div" align="center" gutterBottom>
           {regionName}
         </Typography>
@@ -67,12 +74,32 @@ export default function RegionCard(props) {
         <Grid container justifyContent="center" alignItems="center" pt={1.5}>
           <Grid xs={12}>
             <StyledBox >
-              <img src={regionImage} style={{ maxWidth: '50%', alignSelf: 'center' }} />
+              <img
+              src={regionImage}
+              style={{
+                maxWidth: '50%',
+                alignSelf: 'center'
+              }} />
             </StyledBox>
           </Grid>
         </Grid>
-        <Grid container justifyContent="center" alignItems="center" pt={1.5}>
-          <Grid xs={12}>
+        <Grid
+          container
+          justifyContent="center"
+          alignContent="stretch"
+          pt={1.5}
+          sx={{
+            flexGrow: '1'
+          }}>
+          <Grid
+            xs={12}
+            sx={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'flex-end',
+              justifycontent: 'flex-end'
+            }}
+            alignContent="end">
             <Button
               variant="contained"
               color="CRESTCta"

--- a/src/components/Home/Regions.js
+++ b/src/components/Home/Regions.js
@@ -44,10 +44,16 @@ export default function Regions() {
   };
 
   return (
-    <Grid container spacing={3} justifyContent="center" alignItems="center" px={0.25} py={0.75}>
-
+    <Grid
+      container
+      flexDirection='row'
+      spacing={3}
+      justifyContent="center"
+      alignContent="stretch"
+      px={0.25}
+      py={0.75}>
       { Object.keys(regions).map((region) => (
-        <Grid xs={12} sm={12} md={6} lg={3} xxl={2} key={regions[region].label}>
+        <Grid xs={12} sm={12} md={6} lg={3} xxl={2} key={regions[region].label} >
           <RegionCard
             regionName={regions[region].label}
             regionImage={regions[region].image}

--- a/src/components/Home/TabCallToActionCard.js
+++ b/src/components/Home/TabCallToActionCard.js
@@ -46,8 +46,16 @@ export default function TabCallToActionCard(props) {
   };
 
   return (
-    <Box>
-      <StyledPaper variant="outlined" square={false} >
+    <Box sx={{ 
+      height: '100%' }}>
+      <StyledPaper
+        variant="outlined"
+        square={false}
+        sx={{
+          display: 'flex',
+          height: '100%',
+          flexDirection: 'column'
+        }}>
         <Typography variant="h6" component="div" align="center" gutterBottom style={{ minHeight: '64px' }}>
           {tabLabel}
         </Typography>
@@ -63,8 +71,23 @@ export default function TabCallToActionCard(props) {
             </Box>
           </Grid>
         </Grid>
-        <Grid container justifyContent="center" alignItems="center" pt={1.5}>
-          <Grid xs={12}>
+        <Grid
+          container
+          justifyContent="center"
+          alignContent="stretch"
+          pt={1.5}
+          sx={{
+            flexGrow: '1'
+          }}>
+          <Grid
+            xs={12}
+            sx={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'flex-end',
+              justifycontent: 'flex-end'
+            }}
+            alignContent="end">
             <Button
               variant="contained"
               color="CRESTCta"

--- a/src/components/Home/TabCallToActions.js
+++ b/src/components/Home/TabCallToActions.js
@@ -36,8 +36,14 @@ export default function TabCallToActions() {
   };
 
   return (
-    <Grid container spacing={6} justifyContent="center" alignItems="center" px={0.25} py={0.75}>
-
+    <Grid
+      container
+      flexDirection='row'
+      spacing={3}
+      justifyContent='center'
+      alignContent='stretch'
+      px={0.25}
+      py={0.75}>
       <Grid xs={12} sm={12} md={6} lg={3}>
         <TabCallToActionCard
           tabLabel={'Analyze Project Sites'}


### PR DESCRIPTION
long region titles caused text to wrap and miss alignments with other cards. This should fix the issues no matter how long the region title gets.