### PR TITLE
eslint: remove duplicate 'height' css spec

### DIFF
--- a/src/components/MapLayerList/ChangeItemButton.jsx
+++ b/src/components/MapLayerList/ChangeItemButton.jsx
@@ -93,11 +93,10 @@ export default function ChangeItemButton(props) {
             width: '100%',
             borderRadius: (theme) => theme.spacing(0.5),
             paddingLeft: (theme) => theme.spacing(2),
-            height: '60px',
+            height: 'fit-content',
             textTransform: 'none',
             display: 'flex',
             justifyContent: 'start',
-            height: 'fit-conent',
             '&:hover': {
               backgroundColor: '#6f6f6f'
             }


### PR DESCRIPTION
I know @daveism asked me not to fix these, but here is a simple one. :)

I also wanted to get used to the workflow, so I figured this would be a good way to do so.

This property here is clearly not being used because of a typo (`fit-conent` vs `fit-content`) and there is another `height` property set directly above (`60px`). So it should be safe to remove without affecting anything else.