### PR TITLE
run lint on check (and also on PRs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "check": "prettier --check \"**/*.{js,jsx}\"",
+    "check": "prettier --check \"**/*.{js,jsx}\" && npm run lint",
     "dev": "vite --port 8080",
     "fixlint": "eslint . --ext js,jsx --report-unused-disable-directives --fix",
     "format": "prettier --write \"**/*.{js,jsx}\"",


### PR DESCRIPTION
This adds `npm run lint` to the `check` script. This makes it so we'll run lint on pull requests.


I tested this by creating this pull request and seeing the "Checks" pass (click on the "Checks" tab above to see the log which confirms the linter is being run).