### PR TITLE
fix PropTypes warning on MapCard

### DIFF
--- a/src/components/Map/MapCard.jsx
+++ b/src/components/Map/MapCard.jsx
@@ -32,5 +32,5 @@ MapCard.propTypes = {
   map: PropTypes.object,
   setMap: PropTypes.func,
   mapEventHandlers: PropTypes.objectOf(PropTypes.func),
-  children: PropTypes.arrayOf(PropTypes.element),
+  children: PropTypes.node,
 };


### PR DESCRIPTION
My changes yesterday caused a PropType warning in the console when running Crest.

This fixes it by updating the children PropType to be a `node` instead of an array of `element`s.