### PR TITLE
fix issue with map resizing when layer panel is hidden in ResilienceMapCard

### DIFF
--- a/src/components/Map/AnalyzeProjectSitesMapCard.jsx
+++ b/src/components/Map/AnalyzeProjectSitesMapCard.jsx
@@ -34,8 +34,6 @@ const regions = mapConfig.regions;
 // selector named functions for lint rules makes it easier to re-use if needed.
 const selectedRegionSelector = (state) => state.selectedRegion.value;
 const userInitiatedSelector = (state) => state.selectedRegion.userInitiated;
-const areaVisibleSelector = (state) => state.mapProperties.areaVisible;
-const listVisibleSelector = (state) => state.mapLayerList.visible;
 const drawnLayersSelector = (state) => state.mapProperties.drawnLayers;
 const identifyCoordinatesSelector = (state) =>
   state.mapProperties.identifyCoordinates;
@@ -59,8 +57,6 @@ export default function AnalyzeProjectSitesMapCard(props) {
   const dispatch = useDispatch();
   // setting "() => true" for both center and zoom ensures that value is only read from store once
 
-  const areaVisible = useSelector(areaVisibleSelector);
-  const layerListVisible = useSelector(listVisibleSelector);
   const selectedRegion = useSelector(selectedRegionSelector);
   const userInitiatedRegion = useSelector(userInitiatedSelector);
   const drawnFromState = useSelector(drawnLayersSelector);
@@ -125,14 +121,6 @@ export default function AnalyzeProjectSitesMapCard(props) {
     },
     [map, dispatch],
   );
-
-  useEffect(() => {
-    let timer;
-    if (map) {
-      timer = setTimeout(() => map.invalidateSize(), 10);
-    }
-    return () => clearTimeout(timer);
-  }, [map, areaVisible, layerListVisible]);
 
   useEffect(() => {
     handleRegionChange(selectedRegion, userInitiatedRegion);

--- a/src/components/Map/MapCard.jsx
+++ b/src/components/Map/MapCard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 import { useMapEvents } from "react-leaflet";
@@ -9,8 +9,20 @@ import BasemapLayer from "./BasemapLayer.jsx";
 export default function MapCard({ children, map, setMap, mapEventHandlers }) {
   const selectedCenterSelector = (state) => state.mapProperties.center;
   const selectedZoomSelector = (state) => state.mapProperties.zoom;
+  const listVisibleSelector = (state) => state.mapLayerList.visible;
+  const areaVisibleSelector = (state) => state.mapProperties.areaVisible;
   const center = useSelector(selectedCenterSelector, () => true);
   const zoom = useSelector(selectedZoomSelector, () => true);
+  const layerListVisible = useSelector(listVisibleSelector);
+  const areaVisible = useSelector(areaVisibleSelector);
+
+  useEffect(() => {
+    let timer;
+    if (map) {
+      timer = setTimeout(() => map.invalidateSize(), 10);
+    }
+    return () => clearTimeout(timer);
+  }, [map, areaVisible, layerListVisible]);
 
   // This component exists solely for the useMapEvents hook
   const MapEventsComponent = () => {


### PR DESCRIPTION
This is the issue we talked about last week. I had hoped to find a more elegant way to solve this without the useEffect, but it wasn't meant to be. Here's the bug prior to this change:

![image](https://github.com/nemac/crest-v2/assets/260713/6eddfcf8-6ae6-487d-b071-528922d95c8a)

and after the change the resize works:

![image](https://github.com/nemac/crest-v2/assets/260713/bb8844b3-2ac1-45e8-b367-d07c9c4682b5)

This also moves the areaVisible state into the MapCard. That's only used in the AnalyzeProjectSitesMapCard, so it causes a rerender on the Resilience MapCard, however it ultimately has no effect. We should eventually make that button configurable so it doesn't show up if it's not used.